### PR TITLE
Add automatic builds for ubuntu and mac (intel and arm) and fix #36

### DIFF
--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -123,8 +123,14 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &&
             yum -y update &&
-            yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel &&
-            git clone https://github.com/MobilityDB/MobilityDB &&
+            yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel geos39-devel gsl-devel &&
+            git clone --branch json-c-0.17 --depth 1 https://github.com/json-c/json-c &&
+            mkdir json-c-build &&
+            cd json-c-build &&
+            cmake ../json-c &&
+            make &&
+            make install &&            
+            git clone --depth 1 https://github.com/MobilityDB/MobilityDB &&
             mkdir MobilityDB/build &&
             cd MobilityDB/build &&
             cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so &&

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -78,10 +78,6 @@ jobs:
           make -j
           sudo make install
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-
       - name: Setup Python
         uses: actions/setup-python@v5
 

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -35,9 +35,10 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ./dist/pymeos_cffi-*.tar.gz
+          path: ./pymeos_cffi/dist/pymeos_cffi-*.tar.gz
 
   build_wheels:
+    if: false
     name: Build PyMEOS CFFI for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -13,7 +13,9 @@ jobs:
     name: Build PyMEOS CFFI source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         name: Install Python
         with:
@@ -22,6 +24,7 @@ jobs:
       - name: Check metadata
         working-directory: pymeos_cffi
         run: "python setup.py check"
+
       - name: Build sdist
         working-directory: pymeos_cffi
         run: |
@@ -45,6 +48,9 @@ jobs:
             ld_path: "/opt/homebrew/lib"
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Update brew
         if: matrix.os == 'macos-13'
         # Necessary to avoid issue with macOS runners. See

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -68,14 +68,10 @@ jobs:
         with:
           tools: cmake libpq proj json-c gsl geos
 
-      - name: Fetch MEOS sources
-        if: runner.os == 'macOS'
-        run: |
-          git clone --depth 1 https://github.com/MobilityDB/MobilityDB
-
       - name: Install MEOS
         if: runner.os == 'macOS'
         run: |
+          git clone --depth 1 https://github.com/MobilityDB/MobilityDB
           mkdir MobilityDB/build
           cd MobilityDB/build
           cmake .. -DMEOS=on
@@ -96,6 +92,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "pp*-manylinux*" # Disable PyPy builds on Linux since shapely has no built distributions for them
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
           && yum -y update

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -1,0 +1,79 @@
+name: Build PyMEOS CFFI
+
+on:
+  push:
+    branches:
+      - build-actions
+  create:
+    tags:
+      - "pymeos-cffi-[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  build:
+    name: Build PyMEOS CFFI for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-13, macos-14 ]
+        include:
+          - ld_path: "/usr/local/lib"
+          - os: macos-14
+            ld_path: "/opt/homebrew/lib"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get dependencies from apt (cache)
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        if: runner.os == 'Linux'
+        with:
+          packages: build-essential cmake postgresql-server-dev-14 libproj-dev libjson-c-dev libgsl-dev libgeos-dev
+          version: 1.0
+
+      - name: Update brew
+        if: matrix.os == 'macos-13'
+        # Necessary to avoid issue with macOS runners. See
+        # https://github.com/actions/runner-images/issues/4020
+        run: |
+          brew reinstall python@3.12 || brew link --overwrite python@3.12
+          brew reinstall python@3.11 || brew link --overwrite python@3.11
+          brew update
+
+      - name: Get dependencies from homebrew (cache)
+        uses: tecolicom/actions-use-homebrew-tools@v1
+        if: runner.os == 'macOS'
+        with:
+          tools: cmake libpq proj json-c gsl geos
+
+      - name: Fetch MEOS sources
+        env:
+          BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+        run: |
+          git clone --branch ${{ env.BRANCH_NAME }} --depth 1 https://github.com/MobilityDB/MobilityDB
+
+      - name: Install MEOS
+        run: |
+          mkdir MobilityDB/build
+          cd MobilityDB/build
+          cmake .. -DMEOS=on
+          make -j
+          sudo make install
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.17.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        env:
+          CIBW_TEST_COMMAND: "from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -95,15 +95,15 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-          yum -y update
-          yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel
-          git clone https://github.com/MobilityDB/MobilityDB
-          mkdir MobilityDB/build
-          cd MobilityDB/build
-          cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so
-          make -j
-          make install
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          && yum -y update
+          && yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel
+          && git clone https://github.com/MobilityDB/MobilityDB
+          && mkdir MobilityDB/build
+          && cd MobilityDB/build
+          && cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so
+          && make -j
+          && make install
+          && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
           "
           CIBW_TEST_COMMAND: "from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()"
 

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+#        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ macos-14 ]
         include:
           - ld_path: "/usr/local/lib"
           - os: macos-14

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -43,8 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ ubuntu-latest, macos-13, macos-14 ]
-        os: [ macos-14 ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
         include:
           - ld_path: "/usr/local/lib"
           - os: macos-14

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -105,7 +105,7 @@ jobs:
           && make install
           && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
           "
-          CIBW_TEST_COMMAND: "from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()"
+          CIBW_TEST_COMMAND: "python -c \"from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()\""
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - build-actions
+      - fix-proj-pinning
   create:
     tags:
       - "pymeos-cffi-[0-9]+.[0-9]+.[0-9]+*"
@@ -35,6 +36,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: pymeos_cffi-sdist
           path: ./pymeos_cffi/dist/pymeos_cffi-*.tar.gz
 
   build_wheels:
@@ -45,18 +47,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-14 ]
         include:
-          - os: ubuntu-latest
-            ld_path: "/usr/local/lib"
-            proj_package: "proj81"
-            proj_dir: "/usr/proj81" # PROJ 8.1 latest available in manylinux2014 images
-          - os: macos-13
-            ld_path: "/usr/local/lib"
-            proj_package: "proj@9.4.0"
-            proj_dir: "/usr/local/Cellar/proj/9.4.0"
+          - ld_prefix: "/usr/local"
           - os: macos-14
-            ld_path: "/opt/homebrew/lib"
-            proj_package: "proj@9.4.0"
-            proj_dir: "opt/homebrew/Cellar/proj/9.4.0"
+            ld_prefix: "/opt/homebrew"
 
     steps:
       - name: Checkout
@@ -75,7 +68,15 @@ jobs:
         uses: tecolicom/actions-use-homebrew-tools@v1
         if: runner.os == 'macOS'
         with:
-          tools: cmake libpq ${{ matrix.proj_package }} json-c gsl geos
+          tools: cmake libpq proj json-c gsl geos
+
+      - name: Get PROJ version
+        id: proj_version
+        if: runner.os == 'macOS'
+        run: |
+          proj_version=$(brew list --versions proj)
+          proj_version=${proj_version#* }
+          echo "proj_version=$proj_version" >> $GITHUB_OUTPUT
 
       - name: Install MEOS
         if: runner.os == 'macOS'
@@ -93,12 +94,23 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.17.0
 
+      - name: Set PROJ_DATA (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          PROJ_DATA=${{ matrix.ld_prefix }}/Cellar/proj/${{ steps.proj_version.outputs.proj_version }}/share/proj
+          echo "PROJ_DATA=$PROJ_DATA" >> $GITHUB_ENV
+
+      - name: Set PROJ_DATA (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          PROJ_DATA=/usr/proj81/share/proj
+          echo "PROJ_DATA=$PROJ_DATA" >> $GITHUB_ENV
+
       - name: Build wheels
         working-directory: pymeos_cffi
         run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
-          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
-          export PROJ_DATA=${{ matrix.proj_dir }}/share/proj
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_prefix }}/lib
+          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_prefix }}/lib
           export PACKAGE_DATA=1
           python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -107,25 +119,23 @@ jobs:
           # Disable builds in linux architectures other than x86_64
           CIBW_SKIP: "pp*-manylinux* *musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_BEFORE_ALL_LINUX: "
-          yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-          && yum -y update
-          && yum -y install gcc gcc-c++ make cmake postgresql13-devel ${{ matrix.proj_package }}-devel json-c-devel geos39-devel gsl-devel
-          && export PROJ_DATA=${{ matrix.proj_dir }}/share/proj
-          && export PACKAGE_DATA=1
-          && git clone https://github.com/MobilityDB/MobilityDB
-          && mkdir MobilityDB/build
-          && cd MobilityDB/build
-          && cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=${{ matrix.proj_dir }}/include/ -DPROJ_LIBRARIES=${{ matrix.proj_dir }}/lib/libproj.so
-          && make -j
-          && make install
-          && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          "
+          CIBW_ENVIRONMENT_PASS_LINUX: PACKAGE_DATA LD_LIBRARY_PATH PROJ_DATA
+          CIBW_BEFORE_ALL_LINUX: >
+            yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &&
+            yum -y update &&
+            yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel &&
+            git clone https://github.com/MobilityDB/MobilityDB &&
+            mkdir MobilityDB/build &&
+            cd MobilityDB/build &&
+            cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so &&
+            make -j &&
+            make install
+
           CIBW_TEST_COMMAND: "python -c \"from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()\""
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: pymeos_cffi-wheels-${{ matrix.os }}
           path: ./pymeos_cffi/wheelhouse/*.whl
 
   test_wheels:
@@ -154,7 +164,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: pymeos_cffi-wheels-${{ matrix.os }}
           path: ./pymeos_cffi_wheels
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -96,7 +96,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: "pp*-manylinux*" # Disable PyPy builds on Linux since shapely has no built distributions for them
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64"
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
           && yum -y update

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -1,10 +1,6 @@
 name: Build PyMEOS CFFI
 
 on:
-  push:
-    branches:
-      - build-actions
-      - fix-proj-pinning
   create:
     tags:
       - "pymeos-cffi-[0-9]+.[0-9]+.[0-9]+*"
@@ -200,7 +196,7 @@ jobs:
           path: ./dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -16,10 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
+          cache: "pip"
+
+      - name: Setup pip
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
 
       - name: Build sdist
         working-directory: pymeos_cffi

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -159,7 +159,4 @@ jobs:
 
       - name: Test PyMEOS with pytest
         working-directory: pymeos
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
-          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
-          pytest
+        run: pytest

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -20,8 +20,10 @@ jobs:
           python-version: 3.8
 
       - name: Check metadata
+        working-directory: pymeos_cffi
         run: "python setup.py check"
       - name: Build sdist
+        working-directory: pymeos_cffi
         run: |
           python setup.py sdist 
           ls -l dist
@@ -101,5 +103,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -115,3 +115,51 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}
           path: ./pymeos_cffi/wheelhouse/*.whl
+
+  test_wheels:
+    name: Test PyMEOS CFFI wheel - Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    needs: build_wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
+        exclude:
+          # Necessary due to issue with macOS runners. See
+          # https://github.com/actions/setup-python/issues/808
+          # Can be removed once this PR is merged:
+          # https://github.com/actions/python-versions/pull/259
+          - os: macos-14
+            python-version: "3.8"
+          - os: macos-14
+            python-version: "3.9"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./pymeos_cffi_wheels
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install PyMEOS dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -f ./pymeos_cffi_wheels pymeos_cffi
+          pip install -r pymeos/dev-requirements.txt
+
+      - name: Test PyMEOS with pytest
+        working-directory: pymeos
+        run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
+          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
+          pytest

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -67,7 +67,10 @@ jobs:
 
       - name: Build wheels
         working-directory: pymeos_cffi
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
+          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
+          python -m cibuildwheel --output-dir wheelhouse
         # to supply options, put them in 'env', like:
         env:
           CIBW_TEST_COMMAND: "from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()"

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -160,3 +160,20 @@ jobs:
       - name: Test PyMEOS with pytest
         working-directory: pymeos
         run: pytest
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [ test_wheels, build_sdist ]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -45,9 +45,18 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-14 ]
         include:
-          - ld_path: "/usr/local/lib"
+          - os: ubuntu-latest
+            ld_path: "/usr/local/lib"
+            proj_package: "proj81"
+            proj_dir: "/usr/proj81" # PROJ 8.1 latest available in manylinux2014 images
+          - os: macos-13
+            ld_path: "/usr/local/lib"
+            proj_package: "proj@9.4.0"
+            proj_dir: "/usr/local/Cellar/proj/9.4.0"
           - os: macos-14
             ld_path: "/opt/homebrew/lib"
+            proj_package: "proj@9.4.0"
+            proj_dir: "opt/homebrew/Cellar/proj/9.4.0"
 
     steps:
       - name: Checkout
@@ -66,7 +75,7 @@ jobs:
         uses: tecolicom/actions-use-homebrew-tools@v1
         if: runner.os == 'macOS'
         with:
-          tools: cmake libpq proj json-c gsl geos
+          tools: cmake libpq ${{ matrix.proj_package }} json-c gsl geos
 
       - name: Install MEOS
         if: runner.os == 'macOS'
@@ -89,6 +98,8 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
           export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
+          export PROJ_DATA=${{ matrix.proj_dir }}/share/proj
+          export PACKAGE_DATA=1
           python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable PyPy builds on Linux since shapely has no built distributions for them
@@ -99,11 +110,13 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
           && yum -y update
-          && yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel
+          && yum -y install gcc gcc-c++ make cmake postgresql13-devel ${{ matrix.proj_package }}-devel json-c-devel geos39-devel gsl-devel
+          && export PROJ_DATA=${{ matrix.proj_dir }}/share/proj
+          && export PACKAGE_DATA=1
           && git clone https://github.com/MobilityDB/MobilityDB
           && mkdir MobilityDB/build
           && cd MobilityDB/build
-          && cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so
+          && cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=${{ matrix.proj_dir }}/include/ -DPROJ_LIBRARIES=${{ matrix.proj_dir }}/lib/libproj.so
           && make -j
           && make install
           && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -48,10 +48,8 @@ jobs:
           tools: cmake libpq proj json-c gsl geos
 
       - name: Fetch MEOS sources
-        env:
-          BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
         run: |
-          git clone --branch ${{ env.BRANCH_NAME }} --depth 1 https://github.com/MobilityDB/MobilityDB
+          git clone --depth 1 https://github.com/MobilityDB/MobilityDB
 
       - name: Install MEOS
         run: |

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -78,6 +78,10 @@ jobs:
           make -j
           sudo make install
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+
       - name: Setup Python
         uses: actions/setup-python@v5
 

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -38,7 +38,6 @@ jobs:
           path: ./pymeos_cffi/dist/pymeos_cffi-*.tar.gz
 
   build_wheels:
-    if: false
     name: Build PyMEOS CFFI for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -113,4 +112,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}
-          path: ./wheelhouse/*.whl
+          path: ./pymeos_cffi/wheelhouse/*.whl

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -66,6 +66,7 @@ jobs:
         run: python -m pip install cibuildwheel==2.17.0
 
       - name: Build wheels
+        working-directory: pymeos_cffi
         run: python -m cibuildwheel --output-dir wheelhouse
         # to supply options, put them in 'env', like:
         env:

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -177,3 +177,18 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
+
+  create_release:
+    name: Create GitHub Release
+    needs: [ test_wheels, build_sdist ]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./dist
+          merge-multiple: true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./dist/*

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -95,6 +95,7 @@ jobs:
           export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
           python -m cibuildwheel --output-dir wheelhouse
         env:
+          CIBW_SKIP: "pp*-manylinux*" # Disable PyPy builds on Linux since shapely has no built distributions for them
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
           && yum -y update

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -9,7 +9,28 @@ on:
       - "pymeos-cffi-[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  build:
+  build_sdist:
+    name: Build PyMEOS CFFI source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: 3.8
+
+      - name: Check metadata
+        run: "python setup.py check"
+      - name: Build sdist
+        run: |
+          python setup.py sdist 
+          ls -l dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./dist/pymeos_cffi-*.tar.gz
+
+  build_wheels:
     name: Build PyMEOS CFFI for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,16 +43,6 @@ jobs:
             ld_path: "/opt/homebrew/lib"
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Get dependencies from apt (cache)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        if: runner.os == 'Linux'
-        with:
-          packages: build-essential cmake postgresql-server-dev-14 libproj-dev libjson-c-dev libgsl-dev libgeos-dev
-          version: 1.0
-
       - name: Update brew
         if: matrix.os == 'macos-13'
         # Necessary to avoid issue with macOS runners. See
@@ -48,10 +59,12 @@ jobs:
           tools: cmake libpq proj json-c gsl geos
 
       - name: Fetch MEOS sources
+        if: runner.os == 'macOS'
         run: |
           git clone --depth 1 https://github.com/MobilityDB/MobilityDB
 
       - name: Install MEOS
+        if: runner.os == 'macOS'
         run: |
           mkdir MobilityDB/build
           cd MobilityDB/build
@@ -59,8 +72,8 @@ jobs:
           make -j
           sudo make install
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.17.0
@@ -71,8 +84,19 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
           export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
           python -m cibuildwheel --output-dir wheelhouse
-        # to supply options, put them in 'env', like:
         env:
+          CIBW_BEFORE_ALL_LINUX: "
+          yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+          yum -y update
+          yum -y install gcc gcc-c++ make cmake postgresql13-devel proj81-devel json-c-devel geos39-devel gsl-devel
+          git clone https://github.com/MobilityDB/MobilityDB
+          mkdir MobilityDB/build
+          cd MobilityDB/build
+          cmake .. -DMEOS=on -DGEOS_INCLUDE_DIR=/usr/geos39/include/ -DGEOS_LIBRARY=/usr/geos39/lib64/libgeos_c.so -DGEOS_CONFIG=/usr/geos39/bin/geos-config -DPROJ_INCLUDE_DIRS=/usr/proj81/include/ -DPROJ_LIBRARIES=/usr/proj81/lib/libproj.so
+          make -j
+          make install
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          "
           CIBW_TEST_COMMAND: "from pymeos_cffi import meos_initialize, meos_finalize; meos_initialize('UTC'); meos_finalize()"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Build sdist
         working-directory: pymeos_cffi
         run: |
+          pwd
+          ls -l
           python setup.py sdist 
           ls -l dist
 

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -21,16 +21,10 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Check metadata
-        working-directory: pymeos_cffi
-        run: "python setup.py check"
-
       - name: Build sdist
         working-directory: pymeos_cffi
         run: |
-          pwd
-          ls -l
-          python setup.py sdist 
+          python -m build -s
           ls -l dist
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -100,11 +100,12 @@ jobs:
           PROJ_DATA=${{ matrix.ld_prefix }}/Cellar/proj/${{ steps.proj_version.outputs.proj_version }}/share/proj
           echo "PROJ_DATA=$PROJ_DATA" >> $GITHUB_ENV
 
-      - name: Set PROJ_DATA (Linux)
+      - name: Set PROJ_DATA and JSON-C path (Linux)
         if: runner.os == 'Linux'
         run: |
           PROJ_DATA=/usr/proj81/share/proj
           echo "PROJ_DATA=$PROJ_DATA" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64" >> $GITHUB_ENV
 
       - name: Build wheels
         working-directory: pymeos_cffi

--- a/.github/workflows/build_pymeos_cffi.yml
+++ b/.github/workflows/build_pymeos_cffi.yml
@@ -95,7 +95,10 @@ jobs:
           export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: "pp*-manylinux*" # Disable PyPy builds on Linux since shapely has no built distributions for them
+          # Disable PyPy builds on Linux since shapely has no built distributions for them
+          # Disable builds on musllinux
+          # Disable builds in linux architectures other than x86_64
+          CIBW_SKIP: "pp*-manylinux* *musllinux*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_BEFORE_ALL_LINUX: "
           yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm

--- a/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
+++ b/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import sys
 
@@ -12,27 +13,19 @@ ffibuilder.cdef(content)
 
 
 def get_library_dirs():
-    if sys.platform == "linux":
-        return ["/usr/local/lib"]
-    elif sys.platform == "darwin":
-        if platform.processor() == "arm":
-            return ["/opt/homebrew/lib"]
-        else:
-            return ["/usr/local/lib"]
-    else:
-        raise NotImplementedError("Unsupported platform")
+    paths = [
+        "/usr/local/lib",
+        "/opt/homebrew/lib"
+    ]
+    return [path for path in paths if os.path.exists(path)]
 
 
 def get_include_dirs():
-    if sys.platform == "linux":
-        return ["/usr/local/include"]
-    elif sys.platform == "darwin":
-        if platform.processor() == "arm":
-            return ["/opt/homebrew/include"]
-        else:
-            return ["/usr/local/include"]
-    else:
-        raise NotImplementedError("Unsupported platform")
+    paths = [
+        "/usr/local/include",
+        "/opt/homebrew/include"
+    ]
+    return [path for path in paths if os.path.exists(path)]
 
 
 ffibuilder.set_source(
@@ -42,9 +35,6 @@ ffibuilder.set_source(
     library_dirs=get_library_dirs(),
     include_dirs=get_include_dirs(),
 )  # library name, for the linker
-
-print(f"get_library_dirs: {get_library_dirs()}")
-print(f"get_include_dirs: {get_include_dirs()}")
 
 if __name__ == "__main__":  # not when running with setuptools
     ffibuilder.compile(verbose=True)

--- a/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
+++ b/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
@@ -43,5 +43,8 @@ ffibuilder.set_source(
     include_dirs=get_include_dirs(),
 )  # library name, for the linker
 
+print(f"get_library_dirs: {get_library_dirs()}")
+print(f"get_include_dirs: {get_include_dirs()}")
+
 if __name__ == "__main__":  # not when running with setuptools
     ffibuilder.compile(verbose=True)

--- a/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
+++ b/pymeos_cffi/pymeos_cffi/builder/build_pymeos.py
@@ -1,6 +1,4 @@
 import os
-import platform
-import sys
 
 from cffi import FFI
 
@@ -13,18 +11,12 @@ ffibuilder.cdef(content)
 
 
 def get_library_dirs():
-    paths = [
-        "/usr/local/lib",
-        "/opt/homebrew/lib"
-    ]
+    paths = ["/usr/local/lib", "/opt/homebrew/lib"]
     return [path for path in paths if os.path.exists(path)]
 
 
 def get_include_dirs():
-    paths = [
-        "/usr/local/include",
-        "/opt/homebrew/include"
-    ]
+    paths = ["/usr/local/include", "/opt/homebrew/include"]
     return [path for path in paths if os.path.exists(path)]
 
 
@@ -34,7 +26,7 @@ ffibuilder.set_source(
     libraries=["meos"],
     library_dirs=get_library_dirs(),
     include_dirs=get_include_dirs(),
-)  # library name, for the linker
+)
 
 if __name__ == "__main__":  # not when running with setuptools
     ffibuilder.compile(verbose=True)

--- a/pymeos_cffi/pymeos_cffi/builder/build_pymeos_functions_modifiers.py
+++ b/pymeos_cffi/pymeos_cffi/builder/build_pymeos_functions_modifiers.py
@@ -44,10 +44,11 @@ def meos_initialize_modifier(_: str) -> str:
     return """def meos_initialize(tz_str: "Optional[str]") -> None:
     
     if "PROJ_DATA" not in os.environ and "PROJ_LIB" not in os.environ:
-        # Assume we are in a wheel and the PROJ data is in the package
         proj_dir = os.path.join(os.path.dirname(__file__), "proj_data")
-        os.environ["PROJ_DATA"] = proj_dir
-        os.environ["PROJ_LIB"] = proj_dir
+        if os.path.exists(proj_dir):
+            # Assume we are in a wheel and the PROJ data is in the package
+            os.environ["PROJ_DATA"] = proj_dir
+            os.environ["PROJ_LIB"] = proj_dir
     
     tz_str_converted = tz_str.encode('utf-8') if tz_str is not None else _ffi.NULL
     _lib.meos_initialize(tz_str_converted, _lib.py_error_handler)"""

--- a/pymeos_cffi/pymeos_cffi/builder/build_pymeos_functions_modifiers.py
+++ b/pymeos_cffi/pymeos_cffi/builder/build_pymeos_functions_modifiers.py
@@ -42,6 +42,13 @@ def textset_make_modifier(function: str) -> str:
 
 def meos_initialize_modifier(_: str) -> str:
     return """def meos_initialize(tz_str: "Optional[str]") -> None:
+    
+    if "PROJ_DATA" not in os.environ and "PROJ_LIB" not in os.environ:
+        # Assume we are in a wheel and the PROJ data is in the package
+        proj_dir = os.path.join(os.path.dirname(__file__), "proj_data")
+        os.environ["PROJ_DATA"] = proj_dir
+        os.environ["PROJ_LIB"] = proj_dir
+    
     tz_str_converted = tz_str.encode('utf-8') if tz_str is not None else _ffi.NULL
     _lib.meos_initialize(tz_str_converted, _lib.py_error_handler)"""
 

--- a/pymeos_cffi/pymeos_cffi/builder/templates/functions.py
+++ b/pymeos_cffi/pymeos_cffi/builder/templates/functions.py
@@ -1,4 +1,6 @@
 import logging
+import os
+
 from datetime import datetime, timedelta, date
 from typing import Any, Tuple, Optional, List
 

--- a/pymeos_cffi/pymeos_cffi/functions.py
+++ b/pymeos_cffi/pymeos_cffi/functions.py
@@ -1,4 +1,6 @@
 import logging
+import os
+
 from datetime import datetime, timedelta, date
 from typing import Any, Tuple, Optional, List
 
@@ -203,6 +205,12 @@ def meos_get_intervalstyle() -> str:
 
 
 def meos_initialize(tz_str: "Optional[str]") -> None:
+    if "PROJ_DATA" not in os.environ and "PROJ_LIB" not in os.environ:
+        # Assume we are in a wheel and the PROJ data is in the package
+        proj_dir = os.path.join(os.path.dirname(__file__), "proj_data")
+        os.environ["PROJ_DATA"] = proj_dir
+        os.environ["PROJ_LIB"] = proj_dir
+
     tz_str_converted = tz_str.encode("utf-8") if tz_str is not None else _ffi.NULL
     _lib.meos_initialize(tz_str_converted, _lib.py_error_handler)
 

--- a/pymeos_cffi/setup.py
+++ b/pymeos_cffi/setup.py
@@ -1,7 +1,36 @@
+import os
+import shutil
+
 from setuptools import setup
+
+
+def copy_data_tree(source, destination):
+    try:
+        shutil.rmtree(destination)
+    except OSError:
+        pass
+    shutil.copytree(source, destination)
+
+
+package_data = []
+
+# Conditionally copy PROJ DATA to make self-contained wheels
+if os.environ.get("PACKAGE_DATA"):
+    projdatadir = os.environ.get(
+        "PROJ_DATA", os.environ.get("PROJ_LIB", "/usr/local/share/proj")
+    )
+    if os.path.exists(projdatadir):
+        copy_data_tree(projdatadir, "pymeos_cffi/proj_data")
+    else:
+        raise FileNotFoundError(
+            f"PROJ data directory not found at {projdatadir}. "
+            f"Unable to generate self-contained wheel."
+        )
+    package_data.append("proj_data/*")
 
 setup(
     packages=["pymeos_cffi", "pymeos_cffi.builder"],
     setup_requires=["cffi"],
+    package_data={"pymeos_cffi": package_data},
     cffi_modules=["pymeos_cffi/builder/build_pymeos.py:ffibuilder"],
 )

--- a/pymeos_cffi/setup.py
+++ b/pymeos_cffi/setup.py
@@ -4,33 +4,34 @@ import shutil
 from setuptools import setup
 
 
-def copy_data_tree(source, destination):
-    try:
-        shutil.rmtree(destination)
-    except OSError:
-        pass
-    shutil.copytree(source, destination)
-
-
 package_data = []
 
 # Conditionally copy PROJ DATA to make self-contained wheels
 if os.environ.get("PACKAGE_DATA"):
+    print("Copying PROJ data to package data")
     projdatadir = os.environ.get(
         "PROJ_DATA", os.environ.get("PROJ_LIB", "/usr/local/share/proj")
     )
     if os.path.exists(projdatadir):
-        copy_data_tree(projdatadir, "pymeos_cffi/proj_data")
+        shutil.rmtree("pymeos_cffi/proj_data", ignore_errors=True)
+        shutil.copytree(
+            projdatadir,
+            "pymeos_cffi/proj_data",
+            ignore=shutil.ignore_patterns("*.txt", "*.tif"),
+        )  # Don't copy .tiff files and their related .txt files
     else:
         raise FileNotFoundError(
             f"PROJ data directory not found at {projdatadir}. "
             f"Unable to generate self-contained wheel."
         )
     package_data.append("proj_data/*")
+else:
+    print("Not copying PROJ data to package data")
 
 setup(
     packages=["pymeos_cffi", "pymeos_cffi.builder"],
     setup_requires=["cffi"],
+    include_package_data=True,
     package_data={"pymeos_cffi": package_data},
     cffi_modules=["pymeos_cffi/builder/build_pymeos.py:ffibuilder"],
 )


### PR DESCRIPTION
This PR fixes #36 adding proj_data to built wheel and setting PROJ_DATA env var if not set.
Adds automatic builds for ubuntu and mac (both intel and arm) that are triggered on tag (pymeos-cffi-X.Y.Z).
Build workflow also generates a GitHub release and published packages in PyPI.