### PR TITLE
restrict shapely version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.8'
 dependencies = [
     'pymeos-cffi >=1.1.0, <2',
     'python-dateutil',
-    'shapely',
+    'shapely>=2.0.0',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
looks like `get_srid` only available after shapely 2.0.0