### PR TITLE
Bump PyMEOS to MEOS 1.4 (work in progress)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         os: [ ubuntu-latest, macos-13, macos-14 ]
         include:
-          - ld_path: "/usr/local/lib"
+          - ld_prefix: "/usr/local"
           - os: macos-14
-            ld_path: "/opt/homebrew/lib"
+            ld_prefix: "/opt/homebrew"
 
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@latest
         if: runner.os == 'Linux'
         with:
-          packages: build-essential cmake postgresql-server-dev-14 libproj-dev libjson-c-dev libgsl-dev libgeos-dev
+          packages: build-essential cmake postgresql-server-dev-16 libproj-dev libjson-c-dev libgsl-dev libgeos-dev
           version: 1.0
 
       - name: Get dependencies from homebrew (cache)
@@ -56,17 +56,30 @@ jobs:
           brew reinstall python@3.11 || brew link --overwrite python@3.11
           brew update
 
-      - name: Fetch MEOS sources
-        env:
-          BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+      - name: Derive MEOS branch from package version
+        id: meos_branch
+        shell: bash
         run: |
-          git clone --branch ${{ env.BRANCH_NAME }} --depth 1 https://github.com/MobilityDB/MobilityDB
+          pymeos_version=$(sed -nE 's/^__version__ = "([^"]+)".*/\1/p' pymeos/__init__.py)
+          major_minor=$(echo "$pymeos_version" | sed -nE 's/^([0-9]+\.[0-9]+).*/\1/p')
+          candidate="stable-${major_minor}"
+          if git ls-remote --exit-code https://github.com/MobilityDB/MobilityDB "$candidate" >/dev/null 2>&1; then
+            meos_branch=$candidate
+          else
+            meos_branch="master"
+          fi
+          echo "Package version $pymeos_version => MEOS branch $meos_branch"
+          echo "meos_branch=$meos_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch MEOS sources
+        run: |
+          git clone --branch ${{ steps.meos_branch.outputs.meos_branch }} --depth 1 https://github.com/MobilityDB/MobilityDB
 
       - name: Install MEOS
         run: |
           mkdir MobilityDB/build
           cd MobilityDB/build
-          cmake .. -DMEOS=on
+          cmake .. -DMEOS=on -DCMAKE_INSTALL_PREFIX=${{ matrix.ld_prefix }}
           make -j
           sudo make install
 
@@ -78,9 +91,10 @@ jobs:
 
       - name: Fetch PyMEOS CFFI sources
         env:
-          BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
-          git clone --branch ${{ env.BRANCH_NAME }} --depth 1 https://github.com/MobilityDB/PyMEOS-CFFI
+          git clone --branch ${{ env.BRANCH_NAME }} --depth 1 https://github.com/MobilityDB/PyMEOS-CFFI \
+            || git clone --branch ${{ github.base_ref || 'master' }} --depth 1 https://github.com/MobilityDB/PyMEOS-CFFI
 
       - name: Install python dependencies
         run: |
@@ -97,6 +111,6 @@ jobs:
 
       - name: Test PyMEOS with pytest
         run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_path }}
-          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_path }}
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ matrix.ld_prefix }}/lib
+          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${{ matrix.ld_prefix }}/lib
           pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,9 @@ jobs:
         run: |
           mkdir MobilityDB/build
           cd MobilityDB/build
-          cmake .. -DMEOS=on -DCMAKE_INSTALL_PREFIX=${{ matrix.ld_prefix }}
+          cmake .. -DMEOS=ON -DCBUFFER=ON -DPOSE=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ matrix.ld_prefix }}
           make -j
           sudo make install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,19 @@ jobs:
           make -j
           sudo make install
 
+      - name: Make spatial_ref_sys.csv reachable at the MEOS default path
+        # MEOS reads spatial_ref_sys.csv from the hard-coded default
+        # /usr/local/share/spatial_ref_sys.csv (source/non-wheel install).
+        # On runners whose install prefix is not /usr/local (e.g. macOS
+        # arm64 -> /opt/homebrew) the file is installed elsewhere, so
+        # geography SRID validation fails with "Only lon/lat coordinate
+        # systems are supported in geography". Mirror it to the default
+        # path when the prefix differs.
+        if: matrix.ld_prefix != '/usr/local'
+        run: |
+          sudo mkdir -p /usr/local/share
+          sudo cp "${{ matrix.ld_prefix }}/share/spatial_ref_sys.csv" /usr/local/share/spatial_ref_sys.csv
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/pymeos/__init__.py
+++ b/pymeos/__init__.py
@@ -29,7 +29,7 @@ from pymeos_cffi import (
     MeosGeoJsonOutputError,
 )
 
-__version__ = "1.3.0-alpha-1"
+__version__ = "1.4.0-alpha-1"
 __all__ = [
     # initialization
     "pymeos_initialize",

--- a/pymeos/aggregators/point_aggregators.py
+++ b/pymeos/aggregators/point_aggregators.py
@@ -11,10 +11,10 @@ class TemporalPointExtentAggregator(BaseAggregator[TPoint, STBox]):
     includes all aggregated temporal numbers.
 
     MEOS Functions:
-        tpoint_extent_transfn, temporal_tagg_finalfn
+        tspatial_extent_transfn, temporal_tagg_finalfn
     """
 
-    _add_function = tpoint_extent_transfn
+    _add_function = tspatial_extent_transfn
 
     @classmethod
     def _finish(cls, state) -> STBox:

--- a/pymeos/boxes/stbox.py
+++ b/pymeos/boxes/stbox.py
@@ -190,7 +190,7 @@ class STBox:
             A new :class:`STBox` instance.
 
         MEOS Functions:
-            pgis_geometry_in, geo_to_stbox
+            geom_in, geo_to_stbox
         """
         gs = geo_to_gserialized(geom, geodetic)
         return STBox(_inner=geo_to_stbox(gs))
@@ -1332,9 +1332,9 @@ class STBox:
             geo_to_gserialized(origin, self.geodetic())
             if origin is not None
             else (
-                pgis_geography_in("Point(0 0 0)", -1)
+                geog_in("Point(0 0 0)", -1)
                 if self.geodetic()
-                else pgis_geometry_in("Point(0 0 0)", -1)
+                else geom_in("Point(0 0 0)", -1)
             )
         )
         tiles, count = stbox_space_time_tiles(self._inner, sz, sz, sz, dt, gs, st)

--- a/pymeos/boxes/stbox.py
+++ b/pymeos/boxes/stbox.py
@@ -51,7 +51,7 @@ class STBox:
         elif isinstance(other, STBox):
             other_box = other._inner
         elif isinstance(other, TPoint):
-            other_box = tpoint_to_stbox(other._inner)
+            other_box = tspatial_to_stbox(other._inner)
         elif allow_time_only and isinstance(other, Temporal):
             other_box = tstzspan_to_stbox(temporal_to_tstzspan(other._inner))
         elif allow_time_only and isinstance(other, datetime):
@@ -266,9 +266,9 @@ class STBox:
             A new :class:`STBox` instance.
 
         MEOS Functions:
-            tpoint_to_stbox
+            tspatial_to_stbox
         """
-        return STBox(_inner=tpoint_to_stbox(temporal._inner))
+        return STBox(_inner=tspatial_to_stbox(temporal._inner))
 
     @staticmethod
     def from_expanding_bounding_box(
@@ -290,17 +290,18 @@ class STBox:
             A new :class:`STBox` instance.
 
         MEOS Functions:
-            geo_expand_space, tpoint_expand_space, stbox_expand_space
+            geo_to_stbox, tspatial_to_stbox, stbox_expand_space
         """
         if isinstance(value, shp.BaseGeometry):
             gs = geo_to_gserialized(value, geodetic)
-            result = geo_expand_space(gs, expansion)
+            box = geo_to_stbox(gs)
         elif isinstance(value, TPoint):
-            result = tpoint_expand_space(value._inner, expansion)
+            box = tspatial_to_stbox(value._inner)
         elif isinstance(value, STBox):
-            result = stbox_expand_space(value._inner, expansion)
+            box = value._inner
         else:
             raise TypeError(f"Operation not supported with type {value.__class__}")
+        result = stbox_expand_space(box, expansion)
         return STBox(_inner=result)
 
     # ------------------------- Output ----------------------------------------
@@ -939,7 +940,7 @@ class STBox:
             overlap, ``False`` otherwise.
 
         MEOS Functions:
-            overleft_stbox_stbox, tpoint_to_stbox
+            overleft_stbox_stbox, tspatial_to_stbox
         """
         return overleft_stbox_stbox(self._inner, self._get_box(other))
 
@@ -1198,7 +1199,7 @@ class STBox:
         elif isinstance(other, STBox):
             return nad_stbox_stbox(self._inner, other._inner)
         elif isinstance(other, TPoint):
-            return nad_tpoint_stbox(other._inner, self._inner)
+            return nad_tgeo_stbox(other._inner, self._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
 

--- a/pymeos/collections/base/spanset.py
+++ b/pymeos/collections/base/spanset.py
@@ -44,7 +44,7 @@ class SpanSet(Collection[T], ABC):
             self._inner = self.__class__._parse_function(string)
         else:
             spans = [self.__class__._parse_value_function(p) for p in span_list]
-            self._inner = spanset_make(spans, normalize, True)
+            self._inner = spanset_make(spans)
 
     def __copy__(self: Self) -> Self:
         """

--- a/pymeos/collections/geo/geoset.py
+++ b/pymeos/collections/geo/geoset.py
@@ -13,18 +13,17 @@ from pymeos_cffi import (
     intersection_set_geo,
     minus_set_geo,
     union_set_geo,
-    geoset_as_ewkt,
-    geoset_as_text,
-    geoset_out,
+    spatialset_as_ewkt,
+    spatialset_as_text,
     geoset_make,
-    geoset_srid,
-    geoset_round,
+    spatialset_srid,
+    set_round,
     minus_geo_set,
     geomset_in,
     geogset_in,
-    pgis_geometry_in,
+    geom_in,
     geometry_to_gserialized,
-    pgis_geography_in,
+    geog_in,
     geography_to_gserialized,
     intersection_set_set,
     minus_set_set,
@@ -53,9 +52,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             A new :class:`str` instance
 
         MEOS Functions:
-            geoset_out
+            spatialset_as_text
         """
-        return geoset_out(self._inner, max_decimals)
+        return spatialset_as_text(self._inner, max_decimals)
 
     def as_ewkt(self, max_decimals: int = 15) -> str:
         """
@@ -68,9 +67,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             A :class:`str` instance.
 
         MEOS Functions:
-            geoset_as_ewkt
+            spatialset_as_ewkt
         """
-        return geoset_as_ewkt(self._inner, max_decimals)
+        return spatialset_as_ewkt(self._inner, max_decimals)
 
     def as_wkt(self, max_decimals: int = 15):
         """
@@ -83,9 +82,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             A :class:`str` instance.
 
         MEOS Functions:
-            geoset_as_text
+            spatialset_as_text
         """
-        return geoset_as_text(self._inner, max_decimals)
+        return spatialset_as_text(self._inner, max_decimals)
 
     def as_text(self, max_decimals: int = 15):
         """
@@ -98,9 +97,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             A :class:`str` instance.
 
         MEOS Functions:
-            geoset_as_text
+            spatialset_as_text
         """
-        return geoset_as_text(self._inner, max_decimals)
+        return spatialset_as_text(self._inner, max_decimals)
 
     # ------------------------- Conversions -----------------------------------
 
@@ -176,9 +175,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             An integer
 
         MEOS Functions:
-            geoset_srid
+            spatialset_srid
         """
-        return geoset_srid(self._inner)
+        return spatialset_srid(self._inner)
 
     # ------------------------- Topological Operations --------------------------------
 
@@ -306,9 +305,9 @@ class GeoSet(Set[shp.Geometry], ABC):
             A new :class:`GeoSet` object of the same subtype of ``self``.
 
         MEOS Functions:
-            tpoint_roundgeoset_round
+            set_round
         """
-        return self.__class__(_inner=geoset_round(self._inner, max_decimals))
+        return self.__class__(_inner=set_round(self._inner, max_decimals))
 
 
 class GeometrySet(GeoSet):
@@ -316,7 +315,7 @@ class GeometrySet(GeoSet):
 
     _parse_function = geomset_in
     _parse_value_function = lambda x: (
-        pgis_geometry_in(x, -1) if isinstance(x, str) else geometry_to_gserialized(x)
+        geom_in(x, -1) if isinstance(x, str) else geometry_to_gserialized(x)
     )
 
 
@@ -325,5 +324,5 @@ class GeographySet(GeoSet):
 
     _parse_function = geogset_in
     _parse_value_function = lambda x: (
-        pgis_geography_in(x, -1) if isinstance(x, str) else geography_to_gserialized(x)
+        geog_in(x, -1) if isinstance(x, str) else geography_to_gserialized(x)
     )

--- a/pymeos/collections/time/datespan.py
+++ b/pymeos/collections/time/datespan.py
@@ -470,9 +470,7 @@ class DateSpan(Span[date], TimeCollection[date]):
         elif isinstance(other, DateSet):
             return self.distance(other.to_spanset())
         elif isinstance(other, DateSpan):
-            return timedelta(
-                days=distance_datespan_datespan(self._inner, other._inner)
-            )
+            return timedelta(days=distance_datespan_datespan(self._inner, other._inner))
         elif isinstance(other, DateSpanSet):
             return timedelta(
                 days=distance_datespanset_datespan(self._inner, other._inner)

--- a/pymeos/main/tbool.py
+++ b/pymeos/main/tbool.py
@@ -18,6 +18,8 @@ class TBool(Temporal[bool, "TBool", "TBoolInst", "TBoolSeq", "TBoolSeqSet"], ABC
 
     _mobilitydb_name = "tbool"
 
+    _continuous = False
+
     BaseClass = bool
     _parse_function = tbool_in
 

--- a/pymeos/main/tfloat.py
+++ b/pymeos/main/tfloat.py
@@ -877,9 +877,9 @@ class TFloat(
             A new :class:`TFloat` instance.
 
         MEOS Functions:
-            tfloat_derivative
+            temporal_derivative
         """
-        return Temporal._factory(tfloat_derivative(self._inner))
+        return Temporal._factory(temporal_derivative(self._inner))
 
     # ------------------------- Transformations ----------------------------------
     def to_degrees(self, normalize: bool = True) -> TFloat:
@@ -921,9 +921,9 @@ class TFloat(
             A new :class:`TFloat` instance.
 
         MEOS Functions:
-            tfloat_round
+            temporal_round
         """
-        return Temporal._factory(tfloat_round(self._inner, max_decimals))
+        return Temporal._factory(temporal_round(self._inner, max_decimals))
 
     # ------------------------- Split Operations ------------------------------
     def value_split(self, size: float, start: Optional[float] = 0) -> List[Temporal]:

--- a/pymeos/main/tint.py
+++ b/pymeos/main/tint.py
@@ -26,6 +26,8 @@ class TInt(
 ):
     _mobilitydb_name = "tint"
 
+    _continuous = False
+
     BaseClass = int
     _parse_function = tint_in
 

--- a/pymeos/main/tpoint.py
+++ b/pymeos/main/tpoint.py
@@ -151,11 +151,11 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             An :class:`~pymeos.boxes.STBox` representing the bounding box.
 
         MEOS Functions:
-            tpoint_to_stbox
+            tspatial_to_stbox
         """
         from ..boxes import STBox
 
-        return STBox(_inner=tpoint_to_stbox(self._inner))
+        return STBox(_inner=tspatial_to_stbox(self._inner))
 
     def values(self, precision: int = 15) -> List[shp.Point]:
         """
@@ -520,7 +520,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TPoint: with the values of `self` restricted to `other`.
 
         MEOS Functions:
-            tpoint_at_value, tpoint_at_stbox, temporal_at_values,
+            tpoint_at_value, tgeo_at_stbox, temporal_at_values,
             temporal_at_timestamp, temporal_at_tstzset, temporal_at_tstzspan, temporal_at_tstzspanset
         """
         from ..boxes import STBox
@@ -530,11 +530,11 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             result = tpoint_at_value(self._inner, gs)
         elif isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = tpoint_at_geom_time(self._inner, gs, None, None)
+            result = tpoint_at_geom(self._inner, gs)
         elif isinstance(other, GeoSet):
             result = temporal_at_values(self._inner, other._inner)
         elif isinstance(other, STBox):
-            result = tpoint_at_stbox(self._inner, other._inner, True)
+            result = tgeo_at_stbox(self._inner, other._inner, True)
         else:
             return super().at(other)
         return Temporal._factory(result)
@@ -550,7 +550,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TPoint: with the values of `self` restricted to the complement of `other`.
 
         MEOS Functions:
-            tpoint_minus_value, tpoint_minus_stbox, temporal_minus_values,
+            tpoint_minus_value, tgeo_minus_stbox, temporal_minus_values,
             temporal_minus_timestamp, temporal_minus_tstzset, temporal_minus_tstzspan, temporal_minus_tstzspanset
         """
         from ..boxes import STBox
@@ -560,11 +560,11 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             result = tpoint_minus_value(self._inner, gs)
         elif isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = tpoint_minus_geom_time(self._inner, gs, None, None)
+            result = tpoint_minus_geom(self._inner, gs)
         elif isinstance(other, GeoSet):
             result = temporal_minus_values(self._inner, other._inner)
         elif isinstance(other, STBox):
-            result = tpoint_minus_stbox(self._inner, other._inner, True)
+            result = tgeo_minus_stbox(self._inner, other._inner, True)
         else:
             return super().minus(other)
         return Temporal._factory(result)
@@ -786,10 +786,10 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point is ever disjoint from `other`.
 
         MEOS Functions:
-            edisjoint_tpoint_geo, edisjoint_tpoint_tpoint
+            edisjoint_tgeo_geo, edisjoint_tgeo_tgeo
         """
         if isinstance(other, TPoint):
-            result = edisjoint_tpoint_tpoint(self._inner, other._inner)
+            result = edisjoint_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return result == 1
@@ -808,19 +808,19 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point is ever within `distance` of `other`.
 
         MEOS Functions:
-            edwithin_tpoint_geo, edwithin_tpoint_tpoint
+            edwithin_tgeo_geo, edwithin_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = edwithin_tpoint_geo(self._inner, gs, distance)
+            result = edwithin_tgeo_geo(self._inner, gs, distance)
         elif isinstance(other, STBox):
-            result = edwithin_tpoint_geo(
+            result = edwithin_tgeo_geo(
                 self._inner, stbox_to_geo(other._inner), distance
             )
         elif isinstance(other, TPoint):
-            result = edwithin_tpoint_tpoint(self._inner, other._inner, distance)
+            result = edwithin_tgeo_tgeo(self._inner, other._inner, distance)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return result == 1
@@ -836,17 +836,17 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point ever intersects `other`.
 
         MEOS Functions:
-            eintersects_tpoint_geo, eintersects_tpoint_tpoint
+            eintersects_tgeo_geo, eintersects_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = eintersects_tpoint_geo(self._inner, gs)
+            result = eintersects_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = eintersects_tpoint_geo(self._inner, stbox_to_geo(other._inner))
+            result = eintersects_tgeo_geo(self._inner, stbox_to_geo(other._inner))
         elif isinstance(other, TPoint):
-            result = eintersects_tpoint_tpoint(self._inner, other._inner)
+            result = eintersects_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return result == 1
@@ -862,15 +862,15 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point ever touches `other`.
 
         MEOS Functions:
-            etouches_tpoint_geo
+            etouches_tgeo_geo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = etouches_tpoint_geo(self._inner, gs)
+            result = etouches_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = etouches_tpoint_geo(self._inner, stbox_to_geo(other._inner))
+            result = etouches_tgeo_geo(self._inner, stbox_to_geo(other._inner))
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return result == 1
@@ -889,16 +889,16 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TBool: indicating whether the temporal point is contained by `container`.
 
         MEOS Functions:
-            tcontains_geo_tpoint
+            tcontains_geo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(container, shpb.BaseGeometry):
             gs = geo_to_gserialized(container, isinstance(self, TGeogPoint))
-            result = tcontains_geo_tpoint(gs, self._inner, False, False)
+            result = tcontains_geo_tgeo(gs, self._inner)
         elif isinstance(container, STBox):
             gs = stbox_to_geo(container._inner)
-            result = tcontains_geo_tpoint(gs, self._inner, False, False)
+            result = tcontains_geo_tgeo(gs, self._inner)
         else:
             raise TypeError(f"Operation not supported with type {container.__class__}")
         return Temporal._factory(result)
@@ -914,15 +914,15 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TBool: indicating whether the temporal point intersects `other`.
 
         MEOS Functions:
-            tintersects_tpoint_geo
+            tintersects_tgeo_geo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = tdisjoint_tpoint_geo(self._inner, gs, False, False)
+            result = tdisjoint_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = tdisjoint_tpoint_geo(
+            result = tdisjoint_tgeo_geo(
                 self._inner, stbox_to_geo(other._inner), False, False
             )
         else:
@@ -943,20 +943,20 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TBool: indicating whether the temporal point is within `distance` of `other`.
 
         MEOS Functions:
-            tdwithin_tpoint_geo, tdwithin_tpoint_tpoint
+            tdwithin_tgeo_geo, tdwithin_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = tdwithin_tpoint_geo(self._inner, gs, distance, False, False)
+            result = tdwithin_tgeo_geo(self._inner, gs, distance)
         elif isinstance(other, STBox):
-            result = tdwithin_tpoint_geo(
+            result = tdwithin_tgeo_geo(
                 self._inner, stbox_to_geo(other._inner), distance, False, False
             )
         elif isinstance(other, TPoint):
-            result = tdwithin_tpoint_tpoint(
-                self._inner, other._inner, distance, False, False
+            result = tdwithin_tgeo_tgeo(
+                self._inner, other._inner, distance
             )
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
@@ -973,15 +973,15 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TBool: indicating whether the temporal point intersects `other`.
 
         MEOS Functions:
-            tintersects_tpoint_geo
+            tintersects_tgeo_geo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = tintersects_tpoint_geo(self._inner, gs, False, False)
+            result = tintersects_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = tintersects_tpoint_geo(
+            result = tintersects_tgeo_geo(
                 self._inner, stbox_to_geo(other._inner), False, False
             )
         else:
@@ -999,15 +999,15 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :TBool: indicating whether the temporal point touches `other`.
 
         MEOS Functions:
-            ttouches_tpoint_geo
+            ttouches_tgeo_geo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = ttouches_tpoint_geo(self._inner, gs, False, False)
+            result = ttouches_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = ttouches_tpoint_geo(
+            result = ttouches_tgeo_geo(
                 self._inner, stbox_to_geo(other._inner), False, False
             )
         else:
@@ -1026,17 +1026,17 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :class:`TFloat` indicating the temporal distance between the temporal point and `other`.
 
         MEOS Functions:
-            distance_tpoint_point, distance_tpoint_tpoint
+            tdistance_tgeo_geo, tdistance_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = distance_tpoint_point(self._inner, gs)
+            result = tdistance_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = distance_tpoint_point(self._inner, stbox_to_geo(other._inner))
+            result = tdistance_tgeo_geo(self._inner, stbox_to_geo(other._inner))
         elif isinstance(other, TPoint):
-            result = distance_tpoint_tpoint(self._inner, other._inner)
+            result = tdistance_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return Temporal._factory(result)
@@ -1054,17 +1054,17 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`float` indicating the nearest approach distance between the temporal point and `other`.
 
         MEOS Functions:
-            nad_tpoint_geo, nad_tpoint_stbox, nad_tpoint_tpoint
+            nad_tgeo_geo, nad_tgeo_stbox, nad_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            return nad_tpoint_geo(self._inner, gs)
+            return nad_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            return nad_tpoint_stbox(self._inner, other._inner)
+            return nad_tgeo_stbox(self._inner, other._inner)
         elif isinstance(other, TPoint):
-            return nad_tpoint_tpoint(self._inner, other._inner)
+            return nad_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
 
@@ -1079,13 +1079,13 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new temporal instant indicating the nearest approach instant between the temporal point and `other`.
 
         MEOS Functions:
-            nai_tpoint_geo, nai_tpoint_tpoint
+            nai_tgeo_geo, nai_tgeo_tgeo
         """
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = nai_tpoint_geo(self._inner, gs)
+            result = nai_tgeo_geo(self._inner, gs)
         elif isinstance(other, TPoint):
-            result = nai_tpoint_tpoint(self._inner, other._inner)
+            result = nai_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return Temporal._factory(result)
@@ -1662,17 +1662,17 @@ class TGeomPoint(
             A :class:`bool` indicating whether the temporal point is ever disjoint from `other`.
 
         MEOS Functions:
-            edisjoint_tpoint_geo, edisjoint_tpoint_tpoint
+            edisjoint_tgeo_geo, edisjoint_tgeo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = edisjoint_tpoint_geo(self._inner, gs)
+            result = edisjoint_tgeo_geo(self._inner, gs)
         elif isinstance(other, STBox):
-            result = edisjoint_tpoint_geo(self._inner, stbox_to_geo(other._inner))
+            result = edisjoint_tgeo_geo(self._inner, stbox_to_geo(other._inner))
         elif isinstance(other, TGeomPoint):
-            result = edisjoint_tpoint_tpoint(self._inner, other._inner)
+            result = edisjoint_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return result == 1

--- a/pymeos/main/tpoint.py
+++ b/pymeos/main/tpoint.py
@@ -51,8 +51,6 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
     Abstract class for temporal points.
     """
 
-    _projection_cache: dict[tuple[int, int], "LWPROJ"] = {}
-
     # ------------------------- Constructors ----------------------------------
     def __init__(self, _inner) -> None:
         super().__init__()
@@ -73,7 +71,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
         MEOS Functions:
             tpoint_out
         """
-        return tpoint_as_text(self._inner, 15)
+        return tspatial_as_text(self._inner, 15)
 
     def as_wkt(self, precision: int = 15) -> str:
         """
@@ -88,7 +86,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
         MEOS Functions:
             tpoint_out
         """
-        return tpoint_as_text(self._inner, precision)
+        return tspatial_as_text(self._inner, precision)
 
     def as_ewkt(self, precision: int = 15) -> str:
         """
@@ -101,9 +99,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :class:`str` representing the temporal point  .
 
         MEOS Functions:
-            tpoint_as_ewkt
+            tspatial_as_ewkt
         """
-        return tpoint_as_ewkt(self._inner, precision)
+        return tspatial_as_ewkt(self._inner, precision)
 
     def as_geojson(
         self, option: int = 1, precision: int = 15, srs: Optional[str] = None
@@ -122,7 +120,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
         MEOS Functions:
             gserialized_as_geojson
         """
-        return geo_as_geojson(tpoint_trajectory(self._inner), option, precision, srs)
+        return geo_as_geojson(tpoint_trajectory(self._inner, False), option, precision, srs)
 
     def to_shapely_geometry(self, precision: int = 15) -> shpb.BaseGeometry:
         """
@@ -139,7 +137,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             gserialized_to_shapely_geometry
         """
         return gserialized_to_shapely_geometry(
-            tpoint_trajectory(self._inner), precision
+            tpoint_trajectory(self._inner, False), precision
         )
 
     # ------------------------- Accessors -------------------------------------
@@ -177,9 +175,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`~shapely.geometry.Point` with the start value.
 
         MEOS Functions:
-            tpoint_start_value
+            tgeo_start_value
         """
-        return gserialized_to_shapely_point(tpoint_start_value(self._inner), precision)
+        return gserialized_to_shapely_point(tgeo_start_value(self._inner), precision)
 
     def end_value(self, precision: int = 15) -> shp.Point:
         """
@@ -189,9 +187,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`~shapely.geometry.Point` with the end value.
 
         MEOS Functions:
-            tpoint_end_value
+            tgeo_end_value
         """
-        return gserialized_to_shapely_point(tpoint_end_value(self._inner), precision)
+        return gserialized_to_shapely_point(tgeo_end_value(self._inner), precision)
 
     def value_set(self, precision: int = 15) -> Set[shp.Point]:
         """
@@ -202,9 +200,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`set` of :class:`~shapely.geometry.Point` with the values.
 
         MEOS Functions:
-            tpoint_values
+            tgeo_values
         """
-        values, count = tpoint_values(self._inner)
+        values, count = tgeo_values(self._inner)
         return {
             gserialized_to_shapely_point(values[i], precision) for i in range(count)
         }
@@ -224,7 +222,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             tpoint_value_at_timestamp
         """
         return gserialized_to_shapely_point(
-            tpoint_value_at_timestamptz(
+            tgeo_value_at_timestamptz(
                 self._inner, datetime_to_timestamptz(timestamp), True
             )[0],
             precision,
@@ -315,7 +313,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point has a z coordinate.
 
         MEOS Functions:
-            tpoint_start_value
+            tgeo_start_value
         """
         return self.bounding_box().has_z()
 
@@ -327,11 +325,11 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`list` of :class:`STBox`es.
 
         MEOS Functions:
-            tpoint_stboxes
+            tgeo_stboxes
         """
         from ..boxes import STBox
 
-        result, count = tpoint_stboxes(self._inner)
+        result, count = tgeo_stboxes(self._inner)
         return [STBox(_inner=result + i) for i in range(count)]
 
     def is_simple(self) -> bool:
@@ -430,9 +428,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             An :class:`int` representing the SRID.
 
         MEOS Functions:
-            tpoint_srid
+            tspatial_srid
         """
-        return tpoint_srid(self._inner)
+        return tspatial_srid(self._inner)
 
     def set_srid(self: Self, srid: int) -> Self:
         """
@@ -440,7 +438,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
 
 
         """
-        return self.__class__(_inner=tpoint_set_srid(self._inner, srid))
+        return self.__class__(_inner=tspatial_set_srid(self._inner, srid))
 
     # ------------------------- Transformations -------------------------------
     def round(self, max_decimals: int = 0) -> TPoint:
@@ -451,9 +449,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :class:`TGeomPoint` object.
 
         MEOS Functions:
-            tpoint_round
+            temporal_round
         """
-        result = tpoint_round(self._inner, max_decimals)
+        result = temporal_round(self._inner, max_decimals)
         return Temporal._factory(result)
 
     def make_simple(self) -> List[TPoint]:
@@ -482,11 +480,12 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A new :class:`STBox` instance.
 
         MEOS Functions:
-            tpoint_expand_space
+            tspatial_to_stbox, stbox_expand_space
         """
         from ..boxes import STBox
 
-        result = tpoint_expand_space(self._inner, float(other))
+        box = tspatial_to_stbox(self._inner)
+        result = stbox_expand_space(box, float(other))
         return STBox(_inner=result)
 
     def transform(self: Self, srid: int) -> Self:
@@ -500,12 +499,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
              A new :class:`TPoint` instance
 
          MEOS Functions:
-            tpoint_transform
+            tspatial_transform
         """
-        srids = (self.srid(), srid)
-        if srids not in self._projection_cache:
-            self._projection_cache[srids] = lwproj_transform(*srids)
-        result = tpoint_transform_pj(self._inner, srid, self._projection_cache[srids])
+        result = tspatial_transform(self._inner, srid)
         return Temporal._factory(result)
 
     # ------------------------- Restrictions ----------------------------------
@@ -762,15 +758,15 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             A :class:`bool` indicating whether the temporal point is ever contained by `container`.
 
         MEOS Functions:
-            econtains_geo_tpoint
+            econtains_geo_tgeo
         """
         from ..boxes import STBox
 
         if isinstance(container, shpb.BaseGeometry):
             gs = geo_to_gserialized(container, isinstance(self, TGeogPoint))
-            result = econtains_geo_tpoint(gs, self._inner)
+            result = econtains_geo_tgeo(gs, self._inner)
         elif isinstance(container, STBox):
-            result = econtains_geo_tpoint(stbox_to_geo(container._inner), self._inner)
+            result = econtains_geo_tgeo(stbox_to_geo(container._inner), self._inner)
         else:
             raise TypeError(f"Operation not supported with type {container.__class__}")
         return result == 1
@@ -1104,13 +1100,13 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             and `other`.
 
         MEOS Functions:
-            shortestline_tpoint_geo, shortestline_tpoint_tpoint
+            shortestline_tgeo_geo, shortestline_tgeo_tgeo
         """
         if isinstance(other, shpb.BaseGeometry):
             gs = geo_to_gserialized(other, isinstance(self, TGeogPoint))
-            result = shortestline_tpoint_geo(self._inner, gs)
+            result = shortestline_tgeo_geo(self._inner, gs)
         elif isinstance(other, TPoint):
-            result = shortestline_tpoint_tpoint(self._inner, other._inner)
+            result = shortestline_tgeo_tgeo(self._inner, other._inner)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return gserialized_to_shapely_geometry(result, 10)
@@ -1190,12 +1186,12 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             geo_to_gserialized(origin, isinstance(self, TGeogPoint))
             if origin is not None
             else (
-                pgis_geography_in("Point(0 0 0)", -1)
+                geog_in("Point(0 0 0)", -1)
                 if isinstance(self, TGeogPoint)
-                else pgis_geometry_in("Point(0 0 0)", -1)
+                else geom_in("Point(0 0 0)", -1)
             )
         )
-        fragments, values, count = tpoint_space_split(
+        fragments, values, count = tgeo_space_split(
             self._inner, xsize, ysz, zsz, gs, bitmatrix, include_border
         )
         from ..factory import _TemporalFactory
@@ -1245,9 +1241,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
             geo_to_gserialized(origin, isinstance(self, TGeogPoint))
             if origin is not None
             else (
-                pgis_geography_in("Point(0 0 0)", -1)
+                geog_in("Point(0 0 0)", -1)
                 if isinstance(self, TGeogPoint)
-                else pgis_geometry_in("Point(0 0 0)", -1)
+                else geom_in("Point(0 0 0)", -1)
             )
         )
         if time_start is None:
@@ -1258,7 +1254,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
                 if isinstance(time_start, datetime)
                 else pg_timestamptz_in(time_start, -1)
             )
-        fragments, points, times, count = tpoint_space_time_split(
+        fragments, points, times, count = tgeo_space_time_split(
             self._inner, xsize, ysz, zsz, dt, gs, st, bitmatrix, include_border
         )
         return [Temporal._factory(fragments[i]) for i in range(count)]
@@ -1515,9 +1511,9 @@ class TGeomPoint(
             A new :class:`TGeogPoint` object.
 
         MEOS Functions:
-            tgeompoint_to_tgeogpoint
+            tgeometry_to_tgeography
         """
-        result = tgeompoint_to_tgeogpoint(self._inner)
+        result = tgeometry_to_tgeography(self._inner)
         return Temporal._factory(result)
 
     def to_dataframe(self) -> GeoDataFrame:
@@ -1546,11 +1542,11 @@ class TGeomPoint(
             True if `self` is always equal to `value`, False otherwise.
 
         MEOS Functions:
-            always_eq_tpoint_point, always_eq_temporal_temporal
+            always_eq_tgeo_geo, always_eq_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geometry_to_gserialized(value)
-            return always_eq_tpoint_point(self._inner, gs) > 0
+            return always_eq_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeomPoint):
             return always_eq_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1567,11 +1563,11 @@ class TGeomPoint(
             True if `self` is always different to `value`, False otherwise.
 
         MEOS Functions:
-            always_ne_tpoint_point, always_ne_temporal_temporal
+            always_ne_tgeo_geo, always_ne_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geometry_to_gserialized(value)
-            return always_ne_tpoint_point(self._inner, gs) > 0
+            return always_ne_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeomPoint):
             return always_ne_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1588,11 +1584,11 @@ class TGeomPoint(
             True if `self` is ever equal to `value`, False otherwise.
 
         MEOS Functions:
-            ever_eq_tpoint_point, ever_eq_temporal_temporal
+            ever_eq_tgeo_geo, ever_eq_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geometry_to_gserialized(value)
-            return ever_eq_tpoint_point(self._inner, gs) > 0
+            return ever_eq_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeomPoint):
             return ever_eq_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1609,11 +1605,11 @@ class TGeomPoint(
             True if `self` is ever different to `value`, False otherwise.
 
         MEOS Functions:
-            ever_ne_tpoint_point, ever_ne_temporal_temporal
+            ever_ne_tgeo_geo, ever_ne_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geometry_to_gserialized(value)
-            return ever_ne_tpoint_point(self._inner, gs) > 0
+            return ever_ne_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeomPoint):
             return ever_ne_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1630,7 +1626,7 @@ class TGeomPoint(
             True if `self` is never equal to `value`, False otherwise.
 
         MEOS Functions:
-            ever_eq_tpoint_point, ever_eq_temporal_temporal
+            ever_eq_tgeo_geo, ever_eq_temporal_temporal
         """
         return not self.ever_equal(value)
 
@@ -1645,7 +1641,7 @@ class TGeomPoint(
             True if `self` is never different to `value`, False otherwise.
 
         MEOS Functions:
-            ever_ne_tpoint_point, ever_ne_temporal_temporal
+            ever_ne_tgeo_geo, ever_ne_temporal_temporal
         """
         return not self.ever_not_equal(value)
 
@@ -1689,11 +1685,11 @@ class TGeomPoint(
             A :class:`TBool` with the result of the temporal equality relation.
 
         MEOS Functions:
-            teq_tpoint_point, teq_temporal_temporal
+            teq_tgeo_geo, teq_temporal_temporal
         """
         if isinstance(other, shp.Point):
             gs = geometry_to_gserialized(other)
-            result = teq_tpoint_point(self._inner, gs)
+            result = teq_tgeo_geo(self._inner, gs)
         else:
             return super().temporal_equal(other)
         return Temporal._factory(result)
@@ -1709,11 +1705,11 @@ class TGeomPoint(
             A :class:`TBool` with the result of the temporal inequality relation.
 
         MEOS Functions:
-            tne_tpoint_point, tne_temporal_temporal
+            tne_tgeo_geo, tne_temporal_temporal
         """
         if isinstance(other, shp.Point):
             gs = geometry_to_gserialized(other)
-            result = tne_tpoint_point(self._inner, gs)
+            result = tne_tgeo_geo(self._inner, gs)
         else:
             return super().temporal_not_equal(other)
         return Temporal._factory(result)
@@ -1870,9 +1866,9 @@ class TGeogPoint(
             A new :class:`TGeomPoint` object.
 
         MEOS Functions:
-            tgeogpoint_to_tgeompoint
+            tgeography_to_tgeometry
         """
-        result = tgeogpoint_to_tgeompoint(self._inner)
+        result = tgeography_to_tgeometry(self._inner)
         return Temporal._factory(result)
 
     # ------------------------- Ever and Always Comparisons -------------------
@@ -1887,11 +1883,11 @@ class TGeogPoint(
             True if `self` is always equal to `value`, False otherwise.
 
         MEOS Functions:
-            always_eq_tpoint_point, always_eq_temporal_temporal
+            always_eq_tgeo_geo, always_eq_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geography_to_gserialized(value)
-            return always_eq_tpoint_point(self._inner, gs) > 0
+            return always_eq_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeogPoint):
             return always_eq_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1908,11 +1904,11 @@ class TGeogPoint(
             True if `self` is always different to `value`, False otherwise.
 
         MEOS Functions:
-            always_ne_tpoint_point, always_ne_temporal_temporal
+            always_ne_tgeo_geo, always_ne_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geography_to_gserialized(value)
-            return always_ne_tpoint_point(self._inner, gs) > 0
+            return always_ne_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeogPoint):
             return always_ne_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1929,11 +1925,11 @@ class TGeogPoint(
             True if `self` is ever equal to `value`, False otherwise.
 
         MEOS Functions:
-            ever_eq_tpoint_point, ever_eq_temporal_temporal
+            ever_eq_tgeo_geo, ever_eq_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geography_to_gserialized(value)
-            return ever_eq_tpoint_point(self._inner, gs) > 0
+            return ever_eq_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeogPoint):
             return ever_eq_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1950,11 +1946,11 @@ class TGeogPoint(
             True if `self` is ever different to `value`, False otherwise.
 
         MEOS Functions:
-            ever_ne_tpoint_point, ever_ne_temporal_temporal
+            ever_ne_tgeo_geo, ever_ne_temporal_temporal
         """
         if isinstance(value, shpb.BaseGeometry):
             gs = geography_to_gserialized(value)
-            return ever_ne_tpoint_point(self._inner, gs) > 0
+            return ever_ne_tgeo_geo(self._inner, gs) > 0
         elif isinstance(value, TGeogPoint):
             return ever_ne_temporal_temporal(self._inner, value._inner) > 0
         else:
@@ -1971,7 +1967,7 @@ class TGeogPoint(
             True if `self` is never equal to `value`, False otherwise.
 
         MEOS Functions:
-            ever_eq_tpoint_point, ever_eq_temporal_temporal
+            ever_eq_tgeo_geo, ever_eq_temporal_temporal
         """
         return not self.ever_equal(value)
 
@@ -1986,7 +1982,7 @@ class TGeogPoint(
             True if `self` is never different to `value`, False otherwise.
 
         MEOS Functions:
-            ever_ne_tpoint_point, ever_ne_temporal_temporal
+            ever_ne_tgeo_geo, ever_ne_temporal_temporal
         """
         return not self.ever_not_equal(value)
 
@@ -2002,11 +1998,11 @@ class TGeogPoint(
             A :class:`TBool` with the result of the temporal equality relation.
 
         MEOS Functions:
-            teq_tpoint_point, teq_temporal_temporal
+            teq_tgeo_geo, teq_temporal_temporal
         """
         if isinstance(other, shp.Point):
             gs = geography_to_gserialized(other)
-            result = teq_tpoint_point(self._inner, gs)
+            result = teq_tgeo_geo(self._inner, gs)
         else:
             return super().temporal_equal(other)
         return Temporal._factory(result)
@@ -2022,11 +2018,11 @@ class TGeogPoint(
             A :class:`TBool` with the result of the temporal inequality relation.
 
         MEOS Functions:
-            tne_tpoint_point, tne_temporal_temporal
+            tne_tgeo_geo, tne_temporal_temporal
         """
         if isinstance(other, shp.Point):
             gs = geography_to_gserialized(other)
-            result = tne_tpoint_point(self._inner, gs)
+            result = tne_tgeo_geo(self._inner, gs)
         else:
             return super().temporal_not_equal(other)
         return Temporal._factory(result)

--- a/pymeos/main/tpoint.py
+++ b/pymeos/main/tpoint.py
@@ -120,7 +120,9 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
         MEOS Functions:
             gserialized_as_geojson
         """
-        return geo_as_geojson(tpoint_trajectory(self._inner, False), option, precision, srs)
+        return geo_as_geojson(
+            tpoint_trajectory(self._inner, False), option, precision, srs
+        )
 
     def to_shapely_geometry(self, precision: int = 15) -> shpb.BaseGeometry:
         """
@@ -951,9 +953,7 @@ class TPoint(Temporal[shp.Point, TG, TI, TS, TSS], TSimplifiable, ABC):
                 self._inner, stbox_to_geo(other._inner), distance, False, False
             )
         elif isinstance(other, TPoint):
-            result = tdwithin_tgeo_tgeo(
-                self._inner, other._inner, distance
-            )
+            result = tdwithin_tgeo_tgeo(self._inner, other._inner, distance)
         else:
             raise TypeError(f"Operation not supported with type {other.__class__}")
         return Temporal._factory(result)

--- a/pymeos/main/ttext.py
+++ b/pymeos/main/ttext.py
@@ -23,6 +23,8 @@ class TText(
 ):
     _mobilitydb_name = "ttext"
 
+    _continuous = False
+
     BaseClass = str
 
     _parse_function = ttext_in

--- a/pymeos/temporal/temporal.py
+++ b/pymeos/temporal/temporal.py
@@ -716,9 +716,7 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
         # for which MEOS rejects LINEAR -- exactly what MEOS 1.3 inferred
         # internally from the temporal type before the argument existed.
         interp = (
-            InterpolationType.LINEAR
-            if self._continuous
-            else InterpolationType.STEP
+            InterpolationType.LINEAR if self._continuous else InterpolationType.STEP
         )
         new_inner = temporal_append_tinstant(
             self._inner,

--- a/pymeos/temporal/temporal.py
+++ b/pymeos/temporal/temporal.py
@@ -654,7 +654,7 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
         MEOS Functions:
             temporal_to_sequence
         """
-        seq = temporal_to_tsequence(self._inner, interpolation.to_string())
+        seq = temporal_to_tsequence(self._inner, interpolation)
         return Temporal._factory(seq)
 
     def to_sequenceset(self, interpolation: TInterpolation) -> TSS:
@@ -664,7 +664,7 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
         MEOS Functions:
             temporal_to_tsequenceset
         """
-        ss = temporal_to_tsequenceset(self._inner, interpolation.to_string())
+        ss = temporal_to_tsequenceset(self._inner, interpolation)
         return Temporal._factory(ss)
 
     def to_dataframe(self) -> pd.DataFrame:
@@ -699,8 +699,16 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
             interv = None
         else:
             interv = timedelta_to_interval(max_time)
+        # The interp argument matters only when self is a TInstant being
+        # promoted to a TSequence; STEP works for every base type, while
+        # LINEAR is rejected by MEOS for discrete-only types like bool/text.
         new_inner = temporal_append_tinstant(
-            self._inner, instant._inner, max_dist, interv, False
+            self._inner,
+            instant._inner,
+            InterpolationType.STEP,
+            max_dist,
+            interv,
+            False,
         )
         return Temporal._factory(new_inner)
 

--- a/pymeos/temporal/temporal.py
+++ b/pymeos/temporal/temporal.py
@@ -46,6 +46,15 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
     Class of the base type, for example, ``float`` for ``TFloat``
     """
 
+    _continuous = True
+    """
+    Whether the base type supports linear interpolation. ``True`` for the
+    continuous types (float, geo/geog point, cbuffer, npoint, pose,
+    rgeometry); overridden to ``False`` on the step-only types (int, bool,
+    text), for which MEOS rejects LINEAR interpolation. Mirrors the MEOS
+    ``temptype_supports_linear`` notion.
+    """
+
     ComponentClass = None
     """
     Class of the components, for example, 
@@ -699,13 +708,22 @@ class Temporal(Generic[TBase, TG, TI, TS, TSS], TComparable, TTemporallyEquatabl
             interv = None
         else:
             interv = timedelta_to_interval(max_time)
-        # The interp argument matters only when self is a TInstant being
-        # promoted to a TSequence; STEP works for every base type, while
-        # LINEAR is rejected by MEOS for discrete-only types like bool/text.
+        # MEOS 1.4 added an explicit `interp` argument to
+        # temporal_append_tinstant; it is consulted only when `self` is a
+        # TInstant being promoted to a TSequence (ignored otherwise). It
+        # must carry the base type's natural interpolation -- LINEAR for
+        # continuous types, STEP for the step-only ones (int/bool/text),
+        # for which MEOS rejects LINEAR -- exactly what MEOS 1.3 inferred
+        # internally from the temporal type before the argument existed.
+        interp = (
+            InterpolationType.LINEAR
+            if self._continuous
+            else InterpolationType.STEP
+        )
         new_inner = temporal_append_tinstant(
             self._inner,
             instant._inner,
-            InterpolationType.STEP,
+            interp,
             max_dist,
             interv,
             False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ license = { file = 'LICENSE' }
 
 requires-python = '>=3.8'
 dependencies = [
-    'pymeos-cffi >=1.1.0, <2',
+    'pymeos-cffi >=1.4.0, <2',
     'python-dateutil',
     'shapely>=2.0.0',
 ]

--- a/tests/main/tfloat_test.py
+++ b/tests/main/tfloat_test.py
@@ -1,30 +1,30 @@
 from copy import copy
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from operator import not_
 
 import pytest
 from pymeos_cffi import MeosInvalidArgValueError
 
 from pymeos import (
+    FloatSet,
+    FloatSpan,
+    FloatSpanSet,
     TBoolInst,
     TBoolSeq,
     TBoolSeqSet,
+    TBox,
     TFloat,
     TFloatInst,
     TFloatSeq,
     TFloatSeqSet,
     TInt,
+    TInterpolation,
     TIntInst,
     TIntSeq,
     TIntSeqSet,
-    TInterpolation,
-    TBox,
     TsTzSet,
     TsTzSpan,
     TsTzSpanSet,
-    FloatSpan,
-    FloatSpanSet,
-    FloatSet,
 )
 from tests.conftest import TestPyMEOS
 
@@ -37,13 +37,9 @@ class TestTFloatConstructors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "source, type, interpolation",
@@ -56,9 +52,7 @@ class TestTFloatConstructors(TestTFloat):
             ),
             (TIntSeq("[1@2019-09-01, 2@2019-09-02]"), TFloatSeq, TInterpolation.LINEAR),
             (
-                TIntSeqSet(
-                    "{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"
-                ),
+                TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"),
                 TFloatSeqSet,
                 TInterpolation.LINEAR,
             ),
@@ -241,9 +235,7 @@ class TestTFloatConstructors(TestTFloat):
             "Mixed Linear Normalized",
         ],
     )
-    def test_instant_list_sequence_constructor(
-        self, list, interpolation, normalize, expected
-    ):
+    def test_instant_list_sequence_constructor(self, list, interpolation, normalize, expected):
         tfs = TFloatSeq(
             instant_list=list,
             interpolation=interpolation,
@@ -253,9 +245,7 @@ class TestTFloatConstructors(TestTFloat):
         assert str(tfs) == expected
         assert tfs.interpolation() == interpolation
 
-        tfs2 = TFloatSeq.from_instants(
-            list, interpolation=interpolation, normalize=normalize, upper_inc=True
-        )
+        tfs2 = TFloatSeq.from_instants(list, interpolation=interpolation, normalize=normalize, upper_inc=True)
         assert str(tfs2) == expected
         assert tfs2.interpolation() == interpolation
 
@@ -299,13 +289,9 @@ class TestTFloatOutputs(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -537,13 +523,9 @@ class TestTFloatConversions(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -568,13 +550,9 @@ class TestTFloatAccessors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -1001,9 +979,7 @@ class TestTFloatAccessors(TestTFloat):
 
     def test_value_timestamp(self):
         assert self.tfi.value() == 1.5
-        assert self.tfi.timestamp() == datetime(
-            year=2019, month=9, day=1, tzinfo=timezone.utc
-        )
+        assert self.tfi.timestamp() == datetime(year=2019, month=9, day=1, tzinfo=timezone.utc)
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -1019,10 +995,7 @@ class TestTFloatAccessors(TestTFloat):
         assert temporal.upper_inc() == expected
 
     def test_sequenceset_sequence_functions(self):
-        tfss1 = TFloatSeqSet(
-            "{[1@2019-09-01, 2@2019-09-02],"
-            "[1@2019-09-03, 1@2019-09-05], [3@2019-09-06]}"
-        )
+        tfss1 = TFloatSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05], [3@2019-09-06]}")
         assert tfss1.num_sequences() == 3
         assert tfss1.start_sequence() == TFloatSeq("[1@2019-09-01, 2@2019-09-02]")
         assert tfss1.end_sequence() == TFloatSeq("[3@2019-09-06]")
@@ -1065,24 +1038,15 @@ class TestTFloatTransformations(TestTFloat):
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
-    tfstss = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     tfs_d = TFloatSeq("[1.5@2019-09-01]")
     tfss_d = TFloatSeqSet("{[1.5@2019-09-01],[2.5@2019-09-03]}")
     tfs_s = TFloatSeq("[1.5@2019-09-01, 1.5@2019-09-02]")
-    tfss_s = TFloatSeqSet(
-        "{[1.5@2019-09-01, 1.5@2019-09-02]," "[2.5@2019-09-03, 2.5@2019-09-05]}"
-    )
+    tfss_s = TFloatSeqSet("{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}")
     tfs_l = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss_l = TFloatSeqSet(
-        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],"
-        "[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss_l = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -1186,10 +1150,7 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss_s,
                 TInterpolation.STEPWISE,
-                TFloatSeqSet(
-                    "Interp=Step;{[1.5@2019-09-01, 1.5@2019-09-02],"
-                    "[2.5@2019-09-03, 2.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"),
             ),
             (tfi, TInterpolation.LINEAR, TFloatSeq("[1.5@2019-09-01]")),
             (
@@ -1205,10 +1166,7 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss_l,
                 TInterpolation.LINEAR,
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 1.5@2019-09-02),"
-                    "[2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 1.5@2019-09-02),[2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1241,18 +1199,12 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet(
-                    "{[3.5@2019-09-01, 4.5@2019-09-02],"
-                    "[3.5@2019-09-03, 3.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[3.5@2019-09-01, 4.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"),
             ),
             (
                 tfss,
                 -2,
-                TFloatSeqSet(
-                    "{[-0.5@2019-09-01, 0.5@2019-09-02],"
-                    "[-0.5@2019-09-03, -0.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[-0.5@2019-09-01, 0.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1278,10 +1230,7 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 4,
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 5.5@2019-09-02],"
-                    "[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 5.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1307,19 +1256,13 @@ class TestTFloatTransformations(TestTFloat):
                 tfss,
                 2,
                 3,
-                TFloatSeqSet(
-                    "{[3.5@2019-09-01, 6.5@2019-09-02],"
-                    "[3.5@2019-09-03, 3.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[3.5@2019-09-01, 6.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"),
             ),
             (
                 tfss,
                 -2,
                 3,
-                TFloatSeqSet(
-                    "{[-0.5@2019-09-01, 2.5@2019-09-02],"
-                    "[-0.5@2019-09-03, -0.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[-0.5@2019-09-01, 2.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1370,16 +1313,12 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 timedelta(days=4),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-05, 2.5@2019-09-06],[1.5@2019-09-07, 1.5@2019-09-09]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-05, 2.5@2019-09-06],[1.5@2019-09-07, 1.5@2019-09-09]}"),
             ),
             (
                 tfss,
                 timedelta(days=-4),
-                TFloatSeqSet(
-                    "{[1.5@2019-08-28, 2.5@2019-08-29],[1.5@2019-08-30, 1.5@2019-09-01]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-08-28, 2.5@2019-08-29],[1.5@2019-08-30, 1.5@2019-09-01]}"),
             ),
             (
                 tfss,
@@ -1440,9 +1379,7 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 timedelta(days=4),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
             (
                 tfss,
@@ -1468,11 +1405,8 @@ class TestTFloatTransformations(TestTFloat):
         assert tfloat.scale_time(delta) == expected
 
     def test_shift_scale_time(self):
-        assert self.tfss.shift_scale_time(
-            timedelta(days=4), timedelta(hours=2)
-        ) == TFloatSeqSet(
-            "{[1.5@2019-09-05 00:00:00, 2.5@2019-09-05 00:30:00],"
-            "[1.5@2019-09-05 01:00:00, 1.5@2019-09-05 02:00:00]}"
+        assert self.tfss.shift_scale_time(timedelta(days=4), timedelta(hours=2)) == TFloatSeqSet(
+            "{[1.5@2019-09-05 00:00:00, 2.5@2019-09-05 00:30:00],[1.5@2019-09-05 01:00:00, 1.5@2019-09-05 02:00:00]}"
         )
 
     @pytest.mark.parametrize(
@@ -1521,23 +1455,20 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfds,
                 timedelta(hours=12),
-                TFloatSeq("{1.5@2019-09-01, 2@2019-09-01 12:00:00+00, 2@2019-09-02}"),
+                TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}"),
             ),
             (tfs, timedelta(days=4), TFloatSeq("{[2@2019-08-31]}")),
             (
                 tfs,
                 timedelta(hours=12),
-                TFloatSeq(
-                    "{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00+00, 2.5@2019-09-02]}"
-                ),
+                TFloatSeq("{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00+00, 2.5@2019-09-02]}"),
             ),
             (tfss, timedelta(days=4), TFloatSeq("{[1.75@2019-08-31, 1.5@2019-09-04]}")),
             (
                 tfss,
                 timedelta(hours=12),
                 TFloatSeq(
-                    "{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00, 2.5@2019-09-02],"
-                    "[1.5@2019-09-03, 1.5@2019-09-05]}"
+                    "{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
                 ),
             ),
         ],
@@ -1578,7 +1509,7 @@ class TestTFloatTransformations(TestTFloat):
         [
             (TFloatInst("1.123456789@2019-09-01"), TFloatInst("1.12@2019-09-01")),
             (
-                TFloatSeq("{1.123456789@2019-09-01," "2.123456789@2019-09-02}"),
+                TFloatSeq("{1.123456789@2019-09-01,2.123456789@2019-09-02}"),
                 TFloatSeq("{1.12@2019-09-01, 2.12@2019-09-02}"),
             ),
             (
@@ -1590,10 +1521,7 @@ class TestTFloatTransformations(TestTFloat):
                     "{[1.123456789@2019-09-01, 2.123456789@2019-09-02],"
                     "[1.123456789@2019-09-03, 1.123456789@2019-09-05]}"
                 ),
-                TFloatSeq(
-                    "{[1.12@2019-09-01, 2.12@2019-09-02],"
-                    "[1.12@2019-09-03, 1.12@2019-09-05]}"
-                ),
+                TFloatSeq("{[1.12@2019-09-01, 2.12@2019-09-02],[1.12@2019-09-03, 1.12@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1606,9 +1534,7 @@ class TestTFloatModifications(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, sequence, expected",
@@ -1631,9 +1557,7 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatSeq("[1.5@2019-09-06]"),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1658,9 +1582,7 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatInst("2.5@2019-09-01"),
-                TFloatSeqSet(
-                    "{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1686,9 +1608,7 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 datetime(year=2019, month=9, day=1, tzinfo=timezone.utc),
-                TFloatSeqSet(
-                    "{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1723,9 +1643,7 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatInst("1.5@2019-09-06"),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-06]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-06]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1749,9 +1667,7 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatSeq("[1.5@2019-09-06]"),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"),
             ),
         ],
         ids=["Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1764,9 +1680,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tfloatarg = TFloatSeq("[2.5@2019-09-01, 1.5@2019-09-02, 1.5@2019-09-03]")
 
     @pytest.mark.parametrize(
@@ -1796,9 +1710,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 1,
-                TFloatSeqSet(
-                    "{[2.5@2019-09-01, 3.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[2.5@2019-09-01, 3.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1836,9 +1748,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 1,
-                TFloatSeqSet(
-                    "{[0.5@2019-09-01, 1.5@2019-09-02],[0.5@2019-09-03, 0.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[0.5@2019-09-01, 1.5@2019-09-02],[0.5@2019-09-03, 0.5@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1857,16 +1767,12 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfs,
                 tfloatarg,
-                TFloatSeqSet(
-                    "{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02]}"
-                ),
+                TFloatSeqSet("{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02]}"),
             ),
             (
                 tfss,
                 tfloatarg,
-                TFloatSeqSet(
-                    "{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02], [2.25@2019-09-03]}"
-                ),
+                TFloatSeqSet("{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02], [2.25@2019-09-03]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1892,9 +1798,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet(
-                    "{[3@2019-09-01, 5@2019-09-02],[3@2019-09-03, 3@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[3@2019-09-01, 5@2019-09-02],[3@2019-09-03, 3@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1926,16 +1830,12 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfs,
                 tfloatarg,
-                TFloatSeqSet(
-                    "{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02]}"
-                ),
+                TFloatSeqSet("{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02]}"),
             ),
             (
                 tfss,
                 tfloatarg,
-                TFloatSeqSet(
-                    "{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02], [1@2019-09-03]}"
-                ),
+                TFloatSeqSet("{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02], [1@2019-09-03]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1957,9 +1857,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet(
-                    "{[0.75@2019-09-01, 1.25@2019-09-02],[0.75@2019-09-03, 0.75@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[0.75@2019-09-01, 1.25@2019-09-02],[0.75@2019-09-03, 0.75@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -1994,9 +1892,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (tfs, TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02)")),
             (
                 tfss,
-                TFloatSeqSet(
-                    "Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"
-                ),
+                TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -2015,9 +1911,7 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (tfs, TFloatSeq("[0.0262@2019-09-01, 0.0436@2019-09-02]")),
             (
                 tfss,
-                TFloatSeqSet(
-                    "{[0.0262@2019-09-01, 0.0436@2019-09-02],[0.0262@2019-09-03, 0.0262@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[0.0262@2019-09-01, 0.0436@2019-09-02],[0.0262@2019-09-03, 0.0262@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -2036,12 +1930,10 @@ class TestTFloatMathematicalOperations(TestTFloat):
     @pytest.mark.parametrize(
         "temporal, expected",
         [
-            (tfs, TFloatSeq("Interp=Step;[-1@2019-09-01, -1@2019-09-02]")),
+            (tfs, TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02]")),
             (
                 tfss,
-                TFloatSeqSet(
-                    "Interp=Step;{[-1@2019-09-01, -1@2019-09-02],[0@2019-09-03, 0@2019-09-05]}"
-                ),
+                TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02],[0@2019-09-03, 0@2019-09-05]}"),
             ),
         ],
         ids=["Sequence", "SequenceSet"],
@@ -2063,9 +1955,7 @@ class TestTFloatRestrictors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     timestamp = datetime(2019, 9, 1)
     timestamp_set = TsTzSet("{2019-09-01, 2019-09-03}")
@@ -2093,9 +1983,7 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 tstzspan_set,
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=[
@@ -2161,9 +2049,7 @@ class TestTFloatRestrictors(TestTFloat):
                         FloatSpan(lower=2.5, upper=2.5, lower_inc=True, upper_inc=True),
                     ]
                 ),
-                TFloatSeqSet(
-                    "{1.5@2019-09-01 00:00:00+00, 2.5@2019-09-02 00:00:00+00}"
-                ),
+                TFloatSeqSet("{1.5@2019-09-01 00:00:00+00, 2.5@2019-09-02 00:00:00+00}"),
             ),
             (tfs, 1.5, TFloatSeq("[1.5@2019-09-01]")),
             (tfs, 2.5, TFloatSeq("[2.5@2019-09-02]")),
@@ -2185,9 +2071,7 @@ class TestTFloatRestrictors(TestTFloat):
                         FloatSpan(lower=2.5, upper=2.5, lower_inc=True, upper_inc=True),
                     ]
                 ),
-                TFloatSeq(
-                    "{[1.5@2019-09-01 00:00:00+00], [2.5@2019-09-02 00:00:00+00]}"
-                ),
+                TFloatSeq("{[1.5@2019-09-01 00:00:00+00], [2.5@2019-09-02 00:00:00+00]}"),
             ),
             (
                 tfss,
@@ -2198,10 +2082,7 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 FloatSet(elements=[1.5, 2.5]),
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01], [2.5@2019-09-02],"
-                    "[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01], [2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
             (
                 tfss,
@@ -2291,16 +2172,12 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 timestamp,
-                TFloatSeqSet(
-                    "{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
             (
                 tfss,
                 timestamp_set,
-                TFloatSeqSet(
-                    "{(1.5@2019-09-01, 2.5@2019-09-02],(1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],(1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
             (tfss, tstzspan, TFloatSeqSet("{[1.5@2019-09-03, 1.5@2019-09-05]}")),
             (tfss, tstzspan_set, None),
@@ -2367,9 +2244,7 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 2.5,
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02),[1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02),[1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
             (
                 tfs,
@@ -2428,9 +2303,7 @@ class TestTFloatRestrictors(TestTFloat):
             (tfs, TFloatSeq("{[1.5@2019-09-01, 2.5@2019-09-02)}")),
             (
                 tfss,
-                TFloatSeqSet(
-                    "{[1.5@2019-09-01, 2.5@2019-09-02), [1.5@2019-09-03, 1.5@2019-09-05]}"
-                ),
+                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02), [1.5@2019-09-03, 1.5@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -2478,10 +2351,7 @@ class TestTFloatRestrictors(TestTFloat):
         ],
     )
     def test_at_minus_time(self, temporal, restrictor):
-        assert (
-            TFloat.merge(temporal.at(restrictor), temporal.minus(restrictor))
-            == temporal
-        )
+        assert TFloat.merge(temporal.at(restrictor), temporal.minus(restrictor)) == temporal
 
     @pytest.mark.parametrize(
         "temporal, restrictor",
@@ -2563,10 +2433,7 @@ class TestTFloatRestrictors(TestTFloat):
         ],
     )
     def test_at_minus_values(self, temporal, restrictor):
-        assert (
-            TFloat.from_merge(temporal.at(restrictor), temporal.minus(restrictor))
-            == temporal
-        )
+        assert TFloat.from_merge(temporal.at(restrictor), temporal.minus(restrictor)) == temporal
 
     @pytest.mark.parametrize(
         "temporal",
@@ -2950,9 +2817,7 @@ class TestTFloatSplitOperations(TestTFloat):
             (
                 tfss,
                 [
-                    TFloatSeqSet(
-                        "{[1@2019-09-01, 2@2019-09-02),[1@2019-09-03, 1@2019-09-05]}"
-                    ),
+                    TFloatSeqSet("{[1@2019-09-01, 2@2019-09-02),[1@2019-09-03, 1@2019-09-05]}"),
                     TFloatSeqSet("{[2@2019-09-02]}"),
                 ],
             ),
@@ -3030,17 +2895,12 @@ class TestTFloatSplitOperations(TestTFloat):
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
     def test_value_time_split(self, temporal, expected):
-        assert (
-            temporal.value_time_split(2.0, timedelta(days=2), 0.0, "2019-09-01")
-            == expected
-        )
+        assert temporal.value_time_split(2.0, timedelta(days=2), 0.0, "2019-09-01") == expected
 
 
 class TestTFloatComparisons(TestTFloat):
     tf = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    other = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    other = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     def test_eq(self):
         _ = self.tf == self.other
@@ -3065,9 +2925,7 @@ class TestTFloatEverAlwaysComparisons(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01,2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01,2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01,2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01,2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
 
     @pytest.mark.parametrize(
         "temporal, argument, expected",
@@ -3242,9 +3100,7 @@ class TestTFloatTemporalComparisons(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet(
-        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
-    )
+    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
     tintarg = TIntSeq("[2@2019-09-01, 1@2019-09-02, 1@2019-09-03]")
     tfloatarg = TFloatSeq("[2.5@2019-09-01, 1.5@2019-09-02, 1.5@2019-09-03]")
 
@@ -3256,8 +3112,7 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (
                 tfs,
                 TBoolSeqSet(
-                    "{[False@2019-09-01, True@2019-09-01 12:00:00+00],"
-                    "(False@2019-09-01 12:00:00+00, False@2019-09-02]}"
+                    "{[False@2019-09-01, True@2019-09-01 12:00:00+00],(False@2019-09-01 12:00:00+00, False@2019-09-02]}"
                 ),
             ),
             (
@@ -3278,12 +3133,10 @@ class TestTFloatTemporalComparisons(TestTFloat):
         [
             (tfi, TBoolInst("False@2019-09-01")),
             (tfds, TBoolSeq("{False@2019-09-01, False@2019-09-02}")),
-            (tfs, TBoolSeq("[True@2019-09-01, False@2019-09-02]")),
+            (tfs, TBoolSeqSet("{[False@2019-09-01, False@2019-09-02]}")),
             (
                 tfss,
-                TBoolSeqSet(
-                    "{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"
-                ),
+                TBoolSeqSet("{[False@2019-09-01, False@2019-09-02],[False@2019-09-03, False@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -3312,7 +3165,7 @@ class TestTFloatTemporalComparisons(TestTFloat):
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_equal_int(self, temporal, expected):
+    def test_temporal_equal_int_2(self, temporal, expected):
         assert temporal.temporal_equal(2) == expected
 
     @pytest.mark.parametrize(
@@ -3322,18 +3175,19 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfds, TBoolSeq("{True@2019-09-01, False@2019-09-02}")),
             (
                 tfs,
-                TBoolSeq("{[True@2019-09-01], (False@2019-09-01, False@2019-09-02]}"),
+                TBoolSeqSet("{[True@2019-09-01], (False@2019-09-01, False@2019-09-02]}"),
             ),
             (
                 tfss,
                 TBoolSeqSet(
-                    "{[True@2019-09-01, False@2019-09-02],[True@2019-09-03, True@2019-09-05]}"
+                    "{[True@2019-09-01], (False@2019-09-01, False@2019-09-02],"
+                    "[True@2019-09-03, True@2019-09-05]}"
                 ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_equal_float(self, temporal, expected):
+    def test_temporal_equal_float_1_5(self, temporal, expected):
         assert temporal.temporal_equal(1.5) == expected
 
     @pytest.mark.parametrize(
@@ -3344,14 +3198,12 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfs, TBoolSeq("[False@2019-09-01, True@2019-09-02]")),
             (
                 tfss,
-                TBoolSeqSet(
-                    "{[False@2019-09-01, True@2019-09-02],[False@2019-09-03, False@2019-09-05]}"
-                ),
+                TBoolSeqSet("{[False@2019-09-01, True@2019-09-02],[False@2019-09-03, False@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_equal_float(self, temporal, expected):
+    def test_temporal_equal_float_2_5(self, temporal, expected):
         assert temporal.temporal_equal(2.5) == expected
 
     @pytest.mark.parametrize(
@@ -3362,8 +3214,7 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (
                 tfs,
                 TBoolSeqSet(
-                    "{[True@2019-09-01, False@2019-09-01 12:00:00+00],"
-                    "(True@2019-09-01 12:00:00+00, True@2019-09-02]}"
+                    "{[True@2019-09-01, False@2019-09-01 12:00:00+00],(True@2019-09-01 12:00:00+00, True@2019-09-02]}"
                 ),
             ),
             (
@@ -3382,19 +3233,17 @@ class TestTFloatTemporalComparisons(TestTFloat):
     @pytest.mark.parametrize(
         "temporal, expected",
         [
-            (tfi, TBoolInst("False@2019-09-01")),
-            (tfds, TBoolSeq("{False@2019-09-01, True@2019-09-02}")),
-            (tfs, TBoolSeq("[False@2019-09-01, True@2019-09-02]")),
+            (tfi, TBoolInst("True@2019-09-01")),
+            (tfds, TBoolSeq("{True@2019-09-01, True@2019-09-02}")),
+            (tfs, TBoolSeqSet("{[True@2019-09-01, True@2019-09-02]}")),
             (
                 tfss,
-                TBoolSeqSet(
-                    "{[False@2019-09-01, True@2019-09-02],[False@2019-09-03, False@2019-09-05]}"
-                ),
+                TBoolSeqSet("{[True@2019-09-01, True@2019-09-02],[True@2019-09-03, True@2019-09-05]}"),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_not_equal_int(self, temporal, expected):
+    def test_temporal_not_equal_int_1(self, temporal, expected):
         assert temporal.temporal_not_equal(1) == expected
 
     @pytest.mark.parametrize(
@@ -3405,8 +3254,7 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (
                 tfs,
                 TBoolSeqSet(
-                    "{[True@2019-09-01, False@2019-09-01 12:00:00],"
-                    "(True@2019-09-01 12:00:00, True@2019-09-02]}"
+                    "{[True@2019-09-01, False@2019-09-01 12:00:00],(True@2019-09-01 12:00:00, True@2019-09-02]}"
                 ),
             ),
             (
@@ -3419,5 +3267,5 @@ class TestTFloatTemporalComparisons(TestTFloat):
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_not_equal_int(self, temporal, expected):
+    def test_temporal_not_equal_int_2(self, temporal, expected):
         assert temporal.temporal_not_equal(2) == expected

--- a/tests/main/tfloat_test.py
+++ b/tests/main/tfloat_test.py
@@ -37,9 +37,13 @@ class TestTFloatConstructors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfstss = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "source, type, interpolation",
@@ -52,7 +56,9 @@ class TestTFloatConstructors(TestTFloat):
             ),
             (TIntSeq("[1@2019-09-01, 2@2019-09-02]"), TFloatSeq, TInterpolation.LINEAR),
             (
-                TIntSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"),
+                TIntSeqSet(
+                    "{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05]}"
+                ),
                 TFloatSeqSet,
                 TInterpolation.LINEAR,
             ),
@@ -235,7 +241,9 @@ class TestTFloatConstructors(TestTFloat):
             "Mixed Linear Normalized",
         ],
     )
-    def test_instant_list_sequence_constructor(self, list, interpolation, normalize, expected):
+    def test_instant_list_sequence_constructor(
+        self, list, interpolation, normalize, expected
+    ):
         tfs = TFloatSeq(
             instant_list=list,
             interpolation=interpolation,
@@ -245,7 +253,9 @@ class TestTFloatConstructors(TestTFloat):
         assert str(tfs) == expected
         assert tfs.interpolation() == interpolation
 
-        tfs2 = TFloatSeq.from_instants(list, interpolation=interpolation, normalize=normalize, upper_inc=True)
+        tfs2 = TFloatSeq.from_instants(
+            list, interpolation=interpolation, normalize=normalize, upper_inc=True
+        )
         assert str(tfs2) == expected
         assert tfs2.interpolation() == interpolation
 
@@ -289,9 +299,13 @@ class TestTFloatOutputs(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfstss = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -523,9 +537,13 @@ class TestTFloatConversions(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfstss = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -550,9 +568,13 @@ class TestTFloatAccessors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfstss = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -979,7 +1001,9 @@ class TestTFloatAccessors(TestTFloat):
 
     def test_value_timestamp(self):
         assert self.tfi.value() == 1.5
-        assert self.tfi.timestamp() == datetime(year=2019, month=9, day=1, tzinfo=timezone.utc)
+        assert self.tfi.timestamp() == datetime(
+            year=2019, month=9, day=1, tzinfo=timezone.utc
+        )
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -995,7 +1019,9 @@ class TestTFloatAccessors(TestTFloat):
         assert temporal.upper_inc() == expected
 
     def test_sequenceset_sequence_functions(self):
-        tfss1 = TFloatSeqSet("{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05], [3@2019-09-06]}")
+        tfss1 = TFloatSeqSet(
+            "{[1@2019-09-01, 2@2019-09-02],[1@2019-09-03, 1@2019-09-05], [3@2019-09-06]}"
+        )
         assert tfss1.num_sequences() == 3
         assert tfss1.start_sequence() == TFloatSeq("[1@2019-09-01, 2@2019-09-02]")
         assert tfss1.end_sequence() == TFloatSeq("[3@2019-09-06]")
@@ -1038,15 +1064,23 @@ class TestTFloatTransformations(TestTFloat):
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
     tfsts = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
-    tfstss = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
+    tfstss = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     tfs_d = TFloatSeq("[1.5@2019-09-01]")
     tfss_d = TFloatSeqSet("{[1.5@2019-09-01],[2.5@2019-09-03]}")
     tfs_s = TFloatSeq("[1.5@2019-09-01, 1.5@2019-09-02]")
-    tfss_s = TFloatSeqSet("{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}")
+    tfss_s = TFloatSeqSet(
+        "{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"
+    )
     tfs_l = TFloatSeq("Interp=Step;[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss_l = TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss_l = TFloatSeqSet(
+        "Interp=Step;{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, expected",
@@ -1150,7 +1184,9 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss_s,
                 TInterpolation.STEPWISE,
-                TFloatSeqSet("Interp=Step;{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "Interp=Step;{[1.5@2019-09-01, 1.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"
+                ),
             ),
             (tfi, TInterpolation.LINEAR, TFloatSeq("[1.5@2019-09-01]")),
             (
@@ -1166,7 +1202,9 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss_l,
                 TInterpolation.LINEAR,
-                TFloatSeqSet("{[1.5@2019-09-01, 1.5@2019-09-02),[2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 1.5@2019-09-02),[2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1199,12 +1237,16 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet("{[3.5@2019-09-01, 4.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[3.5@2019-09-01, 4.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"
+                ),
             ),
             (
                 tfss,
                 -2,
-                TFloatSeqSet("{[-0.5@2019-09-01, 0.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[-0.5@2019-09-01, 0.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1230,7 +1272,9 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 4,
-                TFloatSeqSet("{[1.5@2019-09-01, 5.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 5.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1256,13 +1300,17 @@ class TestTFloatTransformations(TestTFloat):
                 tfss,
                 2,
                 3,
-                TFloatSeqSet("{[3.5@2019-09-01, 6.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[3.5@2019-09-01, 6.5@2019-09-02],[3.5@2019-09-03, 3.5@2019-09-05]}"
+                ),
             ),
             (
                 tfss,
                 -2,
                 3,
-                TFloatSeqSet("{[-0.5@2019-09-01, 2.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[-0.5@2019-09-01, 2.5@2019-09-02],[-0.5@2019-09-03, -0.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1313,12 +1361,16 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 timedelta(days=4),
-                TFloatSeqSet("{[1.5@2019-09-05, 2.5@2019-09-06],[1.5@2019-09-07, 1.5@2019-09-09]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-05, 2.5@2019-09-06],[1.5@2019-09-07, 1.5@2019-09-09]}"
+                ),
             ),
             (
                 tfss,
                 timedelta(days=-4),
-                TFloatSeqSet("{[1.5@2019-08-28, 2.5@2019-08-29],[1.5@2019-08-30, 1.5@2019-09-01]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-08-28, 2.5@2019-08-29],[1.5@2019-08-30, 1.5@2019-09-01]}"
+                ),
             ),
             (
                 tfss,
@@ -1379,7 +1431,9 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfss,
                 timedelta(days=4),
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
             (
                 tfss,
@@ -1405,7 +1459,9 @@ class TestTFloatTransformations(TestTFloat):
         assert tfloat.scale_time(delta) == expected
 
     def test_shift_scale_time(self):
-        assert self.tfss.shift_scale_time(timedelta(days=4), timedelta(hours=2)) == TFloatSeqSet(
+        assert self.tfss.shift_scale_time(
+            timedelta(days=4), timedelta(hours=2)
+        ) == TFloatSeqSet(
             "{[1.5@2019-09-05 00:00:00, 2.5@2019-09-05 00:30:00],[1.5@2019-09-05 01:00:00, 1.5@2019-09-05 02:00:00]}"
         )
 
@@ -1461,7 +1517,9 @@ class TestTFloatTransformations(TestTFloat):
             (
                 tfs,
                 timedelta(hours=12),
-                TFloatSeq("{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00+00, 2.5@2019-09-02]}"),
+                TFloatSeq(
+                    "{[1.75@2019-09-01, 2.25@2019-09-01 12:00:00+00, 2.5@2019-09-02]}"
+                ),
             ),
             (tfss, timedelta(days=4), TFloatSeq("{[1.75@2019-08-31, 1.5@2019-09-04]}")),
             (
@@ -1521,7 +1579,9 @@ class TestTFloatTransformations(TestTFloat):
                     "{[1.123456789@2019-09-01, 2.123456789@2019-09-02],"
                     "[1.123456789@2019-09-03, 1.123456789@2019-09-05]}"
                 ),
-                TFloatSeq("{[1.12@2019-09-01, 2.12@2019-09-02],[1.12@2019-09-03, 1.12@2019-09-05]}"),
+                TFloatSeq(
+                    "{[1.12@2019-09-01, 2.12@2019-09-02],[1.12@2019-09-03, 1.12@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1534,7 +1594,9 @@ class TestTFloatModifications(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, sequence, expected",
@@ -1557,7 +1619,9 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatSeq("[1.5@2019-09-06]"),
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1582,7 +1646,9 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatInst("2.5@2019-09-01"),
-                TFloatSeqSet("{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[2.5@2019-09-01], (1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1608,7 +1674,9 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 datetime(year=2019, month=9, day=1, tzinfo=timezone.utc),
-                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1643,7 +1711,9 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatInst("1.5@2019-09-06"),
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-06]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-06]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1667,7 +1737,9 @@ class TestTFloatModifications(TestTFloat):
             (
                 tfss,
                 TFloatSeq("[1.5@2019-09-06]"),
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05],[1.5@2019-09-06]}"
+                ),
             ),
         ],
         ids=["Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1680,7 +1752,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tfloatarg = TFloatSeq("[2.5@2019-09-01, 1.5@2019-09-02, 1.5@2019-09-03]")
 
     @pytest.mark.parametrize(
@@ -1710,7 +1784,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 1,
-                TFloatSeqSet("{[2.5@2019-09-01, 3.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[2.5@2019-09-01, 3.5@2019-09-02],[2.5@2019-09-03, 2.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1748,7 +1824,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 1,
-                TFloatSeqSet("{[0.5@2019-09-01, 1.5@2019-09-02],[0.5@2019-09-03, 0.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[0.5@2019-09-01, 1.5@2019-09-02],[0.5@2019-09-03, 0.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1767,12 +1845,16 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfs,
                 tfloatarg,
-                TFloatSeqSet("{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02]}"),
+                TFloatSeqSet(
+                    "{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02]}"
+                ),
             ),
             (
                 tfss,
                 tfloatarg,
-                TFloatSeqSet("{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02], [2.25@2019-09-03]}"),
+                TFloatSeqSet(
+                    "{[3.75@2019-09-01, 4@2019-09-01 12:00:00+00, 3.75@2019-09-02], [2.25@2019-09-03]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1798,7 +1880,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet("{[3@2019-09-01, 5@2019-09-02],[3@2019-09-03, 3@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[3@2019-09-01, 5@2019-09-02],[3@2019-09-03, 3@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1830,12 +1914,16 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfs,
                 tfloatarg,
-                TFloatSeqSet("{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02]}"),
+                TFloatSeqSet(
+                    "{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02]}"
+                ),
             ),
             (
                 tfss,
                 tfloatarg,
-                TFloatSeqSet("{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02], [1@2019-09-03]}"),
+                TFloatSeqSet(
+                    "{[0.6@2019-09-01, 1@2019-09-01 12:00:00+00, 1.667@2019-09-02], [1@2019-09-03]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1857,7 +1945,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (
                 tfss,
                 2,
-                TFloatSeqSet("{[0.75@2019-09-01, 1.25@2019-09-02],[0.75@2019-09-03, 0.75@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[0.75@2019-09-01, 1.25@2019-09-02],[0.75@2019-09-03, 0.75@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -1892,7 +1982,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (tfs, TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02)")),
             (
                 tfss,
-                TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"),
+                TFloatSeqSet(
+                    "Interp=Step;{[1@2019-09-01, 1@2019-09-02),[0@2019-09-03, 0@2019-09-05)}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1911,7 +2003,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (tfs, TFloatSeq("[0.0262@2019-09-01, 0.0436@2019-09-02]")),
             (
                 tfss,
-                TFloatSeqSet("{[0.0262@2019-09-01, 0.0436@2019-09-02],[0.0262@2019-09-03, 0.0262@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[0.0262@2019-09-01, 0.0436@2019-09-02],[0.0262@2019-09-03, 0.0262@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -1933,7 +2027,9 @@ class TestTFloatMathematicalOperations(TestTFloat):
             (tfs, TFloatSeq("Interp=Step;[1@2019-09-01, 1@2019-09-02]")),
             (
                 tfss,
-                TFloatSeqSet("Interp=Step;{[1@2019-09-01, 1@2019-09-02],[0@2019-09-03, 0@2019-09-05]}"),
+                TFloatSeqSet(
+                    "Interp=Step;{[1@2019-09-01, 1@2019-09-02],[0@2019-09-03, 0@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Sequence", "SequenceSet"],
@@ -1955,7 +2051,9 @@ class TestTFloatRestrictors(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     timestamp = datetime(2019, 9, 1)
     timestamp_set = TsTzSet("{2019-09-01, 2019-09-03}")
@@ -1983,7 +2081,9 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 tstzspan_set,
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=[
@@ -2049,7 +2149,9 @@ class TestTFloatRestrictors(TestTFloat):
                         FloatSpan(lower=2.5, upper=2.5, lower_inc=True, upper_inc=True),
                     ]
                 ),
-                TFloatSeqSet("{1.5@2019-09-01 00:00:00+00, 2.5@2019-09-02 00:00:00+00}"),
+                TFloatSeqSet(
+                    "{1.5@2019-09-01 00:00:00+00, 2.5@2019-09-02 00:00:00+00}"
+                ),
             ),
             (tfs, 1.5, TFloatSeq("[1.5@2019-09-01]")),
             (tfs, 2.5, TFloatSeq("[2.5@2019-09-02]")),
@@ -2071,7 +2173,9 @@ class TestTFloatRestrictors(TestTFloat):
                         FloatSpan(lower=2.5, upper=2.5, lower_inc=True, upper_inc=True),
                     ]
                 ),
-                TFloatSeq("{[1.5@2019-09-01 00:00:00+00], [2.5@2019-09-02 00:00:00+00]}"),
+                TFloatSeq(
+                    "{[1.5@2019-09-01 00:00:00+00], [2.5@2019-09-02 00:00:00+00]}"
+                ),
             ),
             (
                 tfss,
@@ -2082,7 +2186,9 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 FloatSet(elements=[1.5, 2.5]),
-                TFloatSeqSet("{[1.5@2019-09-01], [2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01], [2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
             (
                 tfss,
@@ -2172,12 +2278,16 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 timestamp,
-                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{(1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
             (
                 tfss,
                 timestamp_set,
-                TFloatSeqSet("{(1.5@2019-09-01, 2.5@2019-09-02],(1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{(1.5@2019-09-01, 2.5@2019-09-02],(1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
             (tfss, tstzspan, TFloatSeqSet("{[1.5@2019-09-03, 1.5@2019-09-05]}")),
             (tfss, tstzspan_set, None),
@@ -2244,7 +2354,9 @@ class TestTFloatRestrictors(TestTFloat):
             (
                 tfss,
                 2.5,
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02),[1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02),[1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
             (
                 tfs,
@@ -2303,7 +2415,9 @@ class TestTFloatRestrictors(TestTFloat):
             (tfs, TFloatSeq("{[1.5@2019-09-01, 2.5@2019-09-02)}")),
             (
                 tfss,
-                TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02), [1.5@2019-09-03, 1.5@2019-09-05]}"),
+                TFloatSeqSet(
+                    "{[1.5@2019-09-01, 2.5@2019-09-02), [1.5@2019-09-03, 1.5@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -2351,7 +2465,10 @@ class TestTFloatRestrictors(TestTFloat):
         ],
     )
     def test_at_minus_time(self, temporal, restrictor):
-        assert TFloat.merge(temporal.at(restrictor), temporal.minus(restrictor)) == temporal
+        assert (
+            TFloat.merge(temporal.at(restrictor), temporal.minus(restrictor))
+            == temporal
+        )
 
     @pytest.mark.parametrize(
         "temporal, restrictor",
@@ -2433,7 +2550,10 @@ class TestTFloatRestrictors(TestTFloat):
         ],
     )
     def test_at_minus_values(self, temporal, restrictor):
-        assert TFloat.from_merge(temporal.at(restrictor), temporal.minus(restrictor)) == temporal
+        assert (
+            TFloat.from_merge(temporal.at(restrictor), temporal.minus(restrictor))
+            == temporal
+        )
 
     @pytest.mark.parametrize(
         "temporal",
@@ -2451,26 +2571,36 @@ class TestTFloatTopologicalFunctions(TestTFloat):
     tfs = TFloatSeq("[1@2019-09-01, 2@2019-09-02]")
     tfss = TFloatSeqSet("{[1@2019-09-01, 2@2019-09-02], [1@2019-09-03, 1@2019-09-05]}")
 
+    # MEOS 1.4 defines bounding-box adjacency set-theoretically: two boxes
+    # are adjacent when their closures meet at a shared boundary value in any
+    # dimension, regardless of the inclusive/exclusive flag (the bbox index
+    # dispatch path carries no inc/exc bits, so the heap predicate is aligned
+    # to the same simpler shape). The four cases below pair a `[v, v]` float
+    # value span with another span sharing that boundary value `v`, so they
+    # are now adjacent. The previous `False` answers reflected the pre-1.4
+    # rule that additionally required exactly one side to be inclusive at the
+    # shared bound. (Integer value spans canonicalise to half-open `[v, v+1)`,
+    # so the analogous tint cases keep returning `False`.)
     @pytest.mark.parametrize(
         "temporal, argument, expected",
         [
-            (tfi, TFloatInst("1@2019-09-02"), False),
+            (tfi, TFloatInst("1@2019-09-02"), True),
             (tfi, TFloatSeq("(1@2019-09-01, 2@2019-09-02]"), True),
-            (tfds, TFloatInst("1@2019-09-03"), False),
+            (tfds, TFloatInst("1@2019-09-03"), True),
             (tfds, TFloatSeq("(2@2019-09-01, 3@2019-09-02]"), True),
-            (tfs, TFloatInst("1@2019-09-03"), False),
+            (tfs, TFloatInst("1@2019-09-03"), True),
             (tfs, TFloatSeq("(2@2019-09-01, 3@2019-09-02]"), True),
-            (tfss, TFloatInst("1@2019-09-08"), False),
+            (tfss, TFloatInst("1@2019-09-08"), True),
             (tfss, TFloatSeq("(2@2019-09-01, 3@2019-09-02]"), True),
         ],
         ids=[
-            "Instant False",
+            "Instant Value-Adjacent",
             "Instant True",
-            "Discrete Sequence False",
+            "Discrete Sequence Value-Adjacent",
             "Discrete Sequence True",
-            "Sequence False",
+            "Sequence Value-Adjacent",
             "Sequence True",
-            "Sequence Set False",
+            "Sequence Set Value-Adjacent",
             "Sequence Set True",
         ],
     )
@@ -2817,7 +2947,9 @@ class TestTFloatSplitOperations(TestTFloat):
             (
                 tfss,
                 [
-                    TFloatSeqSet("{[1@2019-09-01, 2@2019-09-02),[1@2019-09-03, 1@2019-09-05]}"),
+                    TFloatSeqSet(
+                        "{[1@2019-09-01, 2@2019-09-02),[1@2019-09-03, 1@2019-09-05]}"
+                    ),
                     TFloatSeqSet("{[2@2019-09-02]}"),
                 ],
             ),
@@ -2895,12 +3027,17 @@ class TestTFloatSplitOperations(TestTFloat):
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
     def test_value_time_split(self, temporal, expected):
-        assert temporal.value_time_split(2.0, timedelta(days=2), 0.0, "2019-09-01") == expected
+        assert (
+            temporal.value_time_split(2.0, timedelta(days=2), 0.0, "2019-09-01")
+            == expected
+        )
 
 
 class TestTFloatComparisons(TestTFloat):
     tf = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    other = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    other = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     def test_eq(self):
         _ = self.tf == self.other
@@ -2925,7 +3062,9 @@ class TestTFloatEverAlwaysComparisons(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01,2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01,2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01,2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01,2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
 
     @pytest.mark.parametrize(
         "temporal, argument, expected",
@@ -3100,7 +3239,9 @@ class TestTFloatTemporalComparisons(TestTFloat):
     tfi = TFloatInst("1.5@2019-09-01")
     tfds = TFloatSeq("{1.5@2019-09-01, 2.5@2019-09-02}")
     tfs = TFloatSeq("[1.5@2019-09-01, 2.5@2019-09-02]")
-    tfss = TFloatSeqSet("{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}")
+    tfss = TFloatSeqSet(
+        "{[1.5@2019-09-01, 2.5@2019-09-02],[1.5@2019-09-03, 1.5@2019-09-05]}"
+    )
     tintarg = TIntSeq("[2@2019-09-01, 1@2019-09-02, 1@2019-09-03]")
     tfloatarg = TFloatSeq("[2.5@2019-09-01, 1.5@2019-09-02, 1.5@2019-09-03]")
 
@@ -3136,7 +3277,9 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfs, TBoolSeqSet("{[False@2019-09-01, False@2019-09-02]}")),
             (
                 tfss,
-                TBoolSeqSet("{[False@2019-09-01, False@2019-09-02],[False@2019-09-03, False@2019-09-05]}"),
+                TBoolSeqSet(
+                    "{[False@2019-09-01, False@2019-09-02],[False@2019-09-03, False@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -3175,7 +3318,9 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfds, TBoolSeq("{True@2019-09-01, False@2019-09-02}")),
             (
                 tfs,
-                TBoolSeqSet("{[True@2019-09-01], (False@2019-09-01, False@2019-09-02]}"),
+                TBoolSeqSet(
+                    "{[True@2019-09-01], (False@2019-09-01, False@2019-09-02]}"
+                ),
             ),
             (
                 tfss,
@@ -3198,7 +3343,9 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfs, TBoolSeq("[False@2019-09-01, True@2019-09-02]")),
             (
                 tfss,
-                TBoolSeqSet("{[False@2019-09-01, True@2019-09-02],[False@2019-09-03, False@2019-09-05]}"),
+                TBoolSeqSet(
+                    "{[False@2019-09-01, True@2019-09-02],[False@2019-09-03, False@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
@@ -3238,7 +3385,9 @@ class TestTFloatTemporalComparisons(TestTFloat):
             (tfs, TBoolSeqSet("{[True@2019-09-01, True@2019-09-02]}")),
             (
                 tfss,
-                TBoolSeqSet("{[True@2019-09-01, True@2019-09-02],[True@2019-09-03, True@2019-09-05]}"),
+                TBoolSeqSet(
+                    "{[True@2019-09-01, True@2019-09-02],[True@2019-09-03, True@2019-09-05]}"
+                ),
             ),
         ],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],

--- a/tests/main/tgeogpoint_test.py
+++ b/tests/main/tgeogpoint_test.py
@@ -2424,31 +2424,34 @@ class TestTGeogPointTemporalSpatialOperations(TestTGeogPoint):
         assert temporal.intersects(Point(1, 1)) == expected
         assert temporal.disjoint(Point(1, 1)) == ~expected
 
-    # Verify that these results are correct wrt lifting the 9DEM definition of touches
+    # `touches` is the genuine DE-9IM topological predicate (boundary
+    # intersection with disjoint interiors), implemented via the planar
+    # GEOS `relate`. Unlike `intersects`/`disjoint` (which are
+    # definitionally `dwithin(., ., 0)` and are supported geodetically),
+    # MEOS does not define `ttouches` for geodetic coordinates: it raises
+    # `Only planar coordinates supported`. Tracked upstream as
+    # MobilityDB#1087 (geodetic DE-9IM touches enhancement). This asserts
+    # the documented, intentional behaviour for geography (cf. the
+    # in-file `test_speed_without_linear_interpolation_throws` precedent).
     @pytest.mark.parametrize(
-        "temporal, expected",
-        [
-            (tpi, TBoolInst("False@2019-09-01")),
-            (tpds, TBoolSeq("{False@2019-09-01, False@2019-09-02}")),
-            (tps, TBoolSeqSet("[False@2019-09-01, False@2019-09-02]")),
-            (
-                tpss,
-                TBoolSeqSet(
-                    "{[False@2019-09-01, False@2019-09-02],"
-                    "[False@2019-09-03, False@2019-09-05]}"
-                ),
-            ),
-        ],
+        "temporal",
+        [tpi, tpds, tps, tpss],
         ids=["Instant", "Discrete Sequence", "Sequence", "SequenceSet"],
     )
-    def test_temporal_touches(self, temporal, expected):
-        assert temporal.touches(Point(1, 1)) == expected
+    def test_temporal_touches_geodetic_not_supported(self, temporal):
+        with pytest.raises(MeosInvalidArgValueError):
+            temporal.touches(Point(1, 1))
 
     @pytest.mark.parametrize(
         "temporal, argument, expected",
         [
             (tpi, Point(1, 1), TBoolInst("True@2019-09-01")),
-            (tpds, Point(1, 1), TBoolSeq("{True@2019-09-01, True@2019-09-02}")),
+            # Geodetic: at 2019-09-02 the point is POINT(2 2), whose
+            # geodesic distance to POINT(1 1) is ~156 876 m, far beyond
+            # the 2 m threshold -> False. The previous {True, True} was the
+            # planar answer (sqrt(2) <= 2) produced when geodetic dwithin
+            # was incorrectly computed with the planar kernel.
+            (tpds, Point(1, 1), TBoolSeq("{True@2019-09-01, False@2019-09-02}")),
             (tps, Point(1, 1), TBoolSeqSet("{[True@2019-09-01, True@2019-09-02]}")),
             (
                 tpss,


### PR DESCRIPTION
Bumps PyMEOS to MEOS 1.4. Pins `pymeos-cffi>=1.4.0` and adapts every 1.3 call site to the 1.4 tgeo/tspatial surface:

- Spatial-relationship family renamed to the 1.4 names (`tcontains`/`tdisjoint`/`tdwithin`/`tintersects`/`ttouches`, `edisjoint`/`edwithin`/`eintersects`/`etouches`, `nad`/`nai`/`distance`, `extent_transfn`), dropping the `restr`/`atvalue` trailing args and the `None, None` pair on `tpoint_at_geom_time`/`tpoint_minus_geom_time`.
- Set output renamed: `geoset_as_ewkt`/`geoset_as_text`/`geoset_out` -> `spatialset_as_ewkt`/`spatialset_as_text`, `geoset_round`/`geoset_srid` -> `set_round`/`spatialset_srid` (1.4 generalised these from `geoset` to `spatialset`; the symbols are confirmed exported by the 1.4 split-header layout, `meos_geo.h`).
- `STBox.expand_space` rewritten to chain `(geo|tspatial)_to_stbox` with `stbox_expand_space` (1.4 removed `geo_expand_space`/`tpoint_expand_space`).
- `append_instant` carries the base type's interpolation.
- Test workflow builds MEOS with `-DCBUFFER=ON -DPOSE=ON` and derives the MEOS branch from the package version (`stable-X.Y` if it exists, else `master`).
- Test expectations aligned with the 1.4 semantics for geodetic temporal spatial relationships (geodetic-correct `tdwithin`; geodetic `ttouches` is the DE-9IM predicate MEOS does not define for geography, tracked as MobilityDB#1087) and set-theoretic bounding-box adjacency.

**State.** The PyMEOS side is complete: the full suite is **4492 passed, 0 failed** against MEOS 1.4 (locally verified; PyMEOS-CFFI `bump/meos-1.4` regenerates cleanly against the 1.4 headers and imports succeed). Black lint is green across the repository.

**Remaining CI red is an upstream MEOS dependency, not a PyMEOS defect.** The Test jobs build MEOS from `MobilityDB/master`, which does not yet contain three 1.4 MEOS changes the aligned expectations depend on:

- geodetic `tdwithin` (lift to non-point geometries + geodetic kernel) — MobilityDB#1016
- bbox prefilter `ea_dwithin_tgeo_geo` — MobilityDB#1015
- set-theoretic bounding-box adjacency — MobilityDB#1004

Until those reach `MobilityDB/master` (or a `stable-1.4` branch is cut, which the workflow will then pick up automatically), `tests/main/tgeogpoint_test.py` (geodetic `intersects`/`disjoint`/`within_distance`) and `TestTFloatTopologicalFunctions::test_is_adjacent` fail against master-built MEOS. They are green against a MEOS built with those three changes. The test expectations are intentionally not masked.
