### PR TITLE
Reformat datespan.py to satisfy Black check

### DIFF
--- a/pymeos/collections/time/datespan.py
+++ b/pymeos/collections/time/datespan.py
@@ -470,9 +470,7 @@ class DateSpan(Span[date], TimeCollection[date]):
         elif isinstance(other, DateSet):
             return self.distance(other.to_spanset())
         elif isinstance(other, DateSpan):
-            return timedelta(
-                days=distance_datespan_datespan(self._inner, other._inner)
-            )
+            return timedelta(days=distance_datespan_datespan(self._inner, other._inner))
         elif isinstance(other, DateSpanSet):
             return timedelta(
                 days=distance_datespanset_datespan(self._inner, other._inner)


### PR DESCRIPTION
Commit e90b35f modified DateSpan.distance without running Black, leaving pymeos/collections/time/datespan.py non Black-clean, so the Lint code with Black workflow fails on master with black ~=24.0 and blocks unrelated PRs. This reformats only that one file with the same Black version the CI uses (24.x), collapsing a single timedelta call onto one line; no other files are touched and there is no behavior change.